### PR TITLE
(WIP) Split order

### DIFF
--- a/svtyper
+++ b/svtyper
@@ -952,6 +952,31 @@ class SplitRead(object):
                  max_unmapped_bases = 50):
         # check for SA tag
         if not self.read.has_tag('SA'):
+            if is_clip_op(self.read.cigar[0][0]) or is_clip_op(self.read.cigar[-1][0]):
+                clip_length = max(self.read.cigar[0][1] * is_clip_op(self.read.cigar[0][0]), self.read.cigar[-1][1] * is_clip_op(self.read.cigar[-1][0]))
+                if clip_length > 0 and (self.read.query_length - self.read.reference_length) <= max_unmapped_bases:
+                    a = self.SplitPiece(self.read.reference_name,
+                                        self.read.reference_start,
+                                        self.read.is_reverse,
+                                        self.read.cigar,
+                                        self.read.mapping_quality)
+                    a.set_reference_end(self.read.reference_end)
+                    b = self.SplitPiece(None,
+                                        1,
+                                        self.read.is_reverse,
+                                        self.read.cigar,
+                                        0)
+                    b.set_reference_end(1)
+                    if is_left_clip(a.cigar):
+                        self.query_left = b
+                        self.query_right = a
+                    else:
+                        self.query_left = a
+                        self.query_right = b
+                    return True
+                else:
+                    return False
+
             return False
 
         # parse SA tag

--- a/svtyper
+++ b/svtyper
@@ -952,9 +952,11 @@ class SplitRead(object):
                  max_unmapped_bases = 50):
         # check for SA tag
         if not self.read.has_tag('SA'):
+            # Include soft-clipped reads that didn't generate split-read alignments
             if is_clip_op(self.read.cigar[0][0]) or is_clip_op(self.read.cigar[-1][0]):
                 clip_length = max(self.read.cigar[0][1] * is_clip_op(self.read.cigar[0][0]), self.read.cigar[-1][1] * is_clip_op(self.read.cigar[-1][0]))
-                if clip_length > 0 and (self.read.query_length - self.read.reference_length) <= max_unmapped_bases:
+                # Only count if the longest clipping event is greater than the cutoff and we have mapped a reasonable number of bases
+                if clip_length > 0 and (self.read.query_length - self.read.query_alignment_length) <= max_unmapped_bases:
                     a = self.SplitPiece(self.read.reference_name,
                                         self.read.reference_start,
                                         self.read.is_reverse,
@@ -1161,6 +1163,11 @@ def cigarstring_to_tuple(cigarstring):
     return [(cigar_dict[pair[1]], int(pair[0])) for pair in paired]
 
 def is_left_clip(cigar):
+    '''
+    whether the left side of the read (w/ respect to reference) is clipped.
+    Clipping side is determined as the side with the longest clip.
+    Adjacent clipping operations are not considered
+    '''
     left_tuple = cigar[0]
     right_tuple = cigar[-1]
     left_clipped = is_clip_op(left_tuple[0])
@@ -1169,6 +1176,9 @@ def is_left_clip(cigar):
     return (left_clipped and not right_clipped) or (left_clipped and right_clipped and left_tuple[1] > right_tuple[1])
 
 def is_clip_op(op):
+    '''
+    whether the CIGAR OP code represents a clipping event
+    '''
     return op == 4 or op == 5
 
 # reference position where the alignment would have started

--- a/svtyper
+++ b/svtyper
@@ -989,7 +989,7 @@ class SplitRead(object):
             self.query_left = b
             self.query_right = a
         else:
-            if is_clip(a.cigar[0]):
+            if is_left_clip(a.cigar):
                 self.query_left = b
                 self.query_right = a
             else:
@@ -1135,8 +1135,16 @@ def cigarstring_to_tuple(cigarstring):
     paired = (values[n:n+2] for n in xrange(0, len(values), 2)) ## pair values by twos
     return [(cigar_dict[pair[1]], int(pair[0])) for pair in paired]
 
-def is_clip(cigar_tuple):
-    return cigar_tuple[0] == 4 or cigar_tuple[0] == 5
+def is_left_clip(cigar):
+    left_tuple = cigar[0]
+    right_tuple = cigar[-1]
+    left_clipped = is_clip_op(left_tuple[0])
+    right_clipped = is_clip_op(right_tuple[0])
+
+    return (left_clipped and not right_clipped) or (left_clipped and right_clipped and left_tuple[1] > right_tuple[1])
+
+def is_clip_op(op):
+    return op == 4 or op == 5
 
 # reference position where the alignment would have started
 # if the entire query sequence would have aligned

--- a/svtyper
+++ b/svtyper
@@ -989,8 +989,12 @@ class SplitRead(object):
             self.query_left = b
             self.query_right = a
         else:
-            self.query_left = a
-            self.query_right = b
+            if is_clip(a.cigar[0]):
+                self.query_left = b
+                self.query_right = a
+            else:
+                self.query_left = a
+                self.query_right = b
 
         # check non-overlap
         if self.non_overlap() < min_non_overlap:
@@ -1130,6 +1134,9 @@ def cigarstring_to_tuple(cigarstring):
     values = pattern.split(cigarstring)[:-1] ## turn cigar into tuple of values
     paired = (values[n:n+2] for n in xrange(0, len(values), 2)) ## pair values by twos
     return [(cigar_dict[pair[1]], int(pair[0])) for pair in paired]
+
+def is_clip(cigar_tuple):
+    return cigar_tuple[0] == 4 or cigar_tuple[0] == 5
 
 # reference position where the alignment would have started
 # if the entire query sequence would have aligned

--- a/svtyper
+++ b/svtyper
@@ -969,12 +969,7 @@ class SplitRead(object):
                                         self.read.cigar,
                                         0)
                     b.set_reference_end(1)
-                    if is_left_clip(a.cigar):
-                        self.query_left = b
-                        self.query_right = a
-                    else:
-                        self.query_left = a
-                        self.query_right = b
+                    self.set_order_by_clip(a, b)
                     return True
                 else:
                     return False
@@ -1016,12 +1011,7 @@ class SplitRead(object):
             self.query_left = b
             self.query_right = a
         else:
-            if is_left_clip(a.cigar):
-                self.query_left = b
-                self.query_right = a
-            else:
-                self.query_left = a
-                self.query_right = b
+            self.set_order_by_clip(a, b)
 
         # check non-overlap
         if self.non_overlap() < min_non_overlap:
@@ -1148,6 +1138,18 @@ class SplitRead(object):
         self.read.set_tag('XV', value)
 
         return
+
+    def set_order_by_clip(self, a, b): 
+        '''
+        Determine which SplitPiece is the leftmost based
+        on the side of the longest clipping operation
+        '''
+        if is_left_clip(a.cigar):
+            self.query_left = b
+            self.query_right = a
+        else:
+            self.query_left = a
+            self.query_right = b
 
 
 # ==================================================


### PR DESCRIPTION
These changes do two things:

1. Order the arrangement of split-reads, where the two halves are not on the same chromosome, by the location of the clipping.
2. Count soft-clips as split-reads where the soft-clipped section of the reads is treated as not supporting the breakpoint, but of 0 quality. This allows the mapped portion of the read to support the breakpoint, assuming that the location of the soft-clipping event would do so.

I am still evaluating these changes, but wanted to get the code out there.