### PR TITLE
Update README.md to correctly clone repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Requirements
 
 Clone the repository
 ```
-git clone git@github.com:hall-lab/svtyper.git
+git clone https://github.com/hall-lab/svtyper.git
 ```
 
 Test the installation


### PR DESCRIPTION
The previous syntax fails when the user has a git profile with an SSH key for validation. This syntax follows the GitHub recommended repo link and should work for more users.