### PR TITLE
Update pysam dependency to pysam>=0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Requirements:
 
     pip install git+https://github.com/hall-lab/svtyper.git
 
-`svtyper` depends on [pysam][0] _(version 0.8.1 or newer)_, [numpy][1], and [scipy][2]; `svtyper-sso` additionally depends on [cytoolz][7]. If the dependencies aren't already available on your system, `pip` will attempt to download and install them.
+`svtyper` depends on [pysam][0] _(version 0.12.0 or newer)_, [numpy][1], and [scipy][2]; `svtyper-sso` additionally depends on [cytoolz][7]. If the dependencies aren't already available on your system, `pip` will attempt to download and install them.
 
 ## `svtyper` vs `svtyper-sso`
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     install_requires=[
-        'pysam>=0.8.1',
+        'pysam>=0.12.0',
         'numpy',
         'scipy',
         'cytoolz>=0.8.2',


### PR DESCRIPTION
The README and setup.py files list pysam 0.8.1 as a minimum version, but
this is no longer correct beginning with v0.4.0