### PR TITLE
if CI is too big, use CI95

### DIFF
--- a/svtyper/classic.py
+++ b/svtyper/classic.py
@@ -123,7 +123,8 @@ def sv_genotype(bam_string,
         if b.endswith('.bam'):
             bam_list.append(pysam.AlignmentFile(b, mode='rb'))
         elif b.endswith('.cram'):
-            bam_list.append(pysam.AlignmentFile(b, mode='rc', reference_filename=ref_fasta))
+            bam_list.append(pysam.AlignmentFile(b,
+                mode='rc',reference_filename=ref_fasta,format_options=["required_fields=7167"]))
         else:
             sys.stderr.write('Error: %s is not a valid alignment file (*.bam or *.cram)\n' % b)
             exit(1)

--- a/svtyper/classic.py
+++ b/svtyper/classic.py
@@ -236,12 +236,12 @@ def sv_genotype(bam_string,
                 posA = var.pos
                 posB = var2.pos
                 # confidence intervals
-                ciA = map(int, var.info['CIPOS'].split(','))
-                ciB = map(int, var2.info['CIPOS'].split(','))
-                if ciA[1] - ciA[0] > 200:
+                if "CIPOS95" in var.info:
                     ciA = map(int, var.info['CIPOS95'].split(','))
-                if ciB[1] - ciB[0] > 200:
                     ciB = map(int, var2.info['CIPOS95'].split(','))
+                else:
+                    ciA = map(int, var.info['CIPOS'].split(','))
+                    ciB = map(int, var2.info['CIPOS'].split(','))
 
                 # infer the strands from the alt allele
                 if var.alt[-1] == '[' or var.alt[-1] == ']':
@@ -263,12 +263,12 @@ def sv_genotype(bam_string,
             posA = var.pos
             posB = int(var.get_info('END'))
             # confidence intervals
-            ciA = map(int, var.info['CIPOS'].split(','))
-            ciB = map(int, var.info['CIEND'].split(','))
-            if ciA[1] - ciA[0] > 200:
+            if "CIPOS95" in var.info:
                 ciA = map(int, var.info['CIPOS95'].split(','))
-            if ciB[1] - ciB[0] > 200:
                 ciB = map(int, var.info['CIEND95'].split(','))
+            else:
+                ciA = map(int, var.info['CIPOS'].split(','))
+                ciB = map(int, var.info['CIEND'].split(','))
             if svtype == 'DEL':
                 var_length = posB - posA
                 o1_is_reverse, o2_is_reverse =  False, True

--- a/svtyper/classic.py
+++ b/svtyper/classic.py
@@ -238,6 +238,10 @@ def sv_genotype(bam_string,
                 # confidence intervals
                 ciA = map(int, var.info['CIPOS'].split(','))
                 ciB = map(int, var2.info['CIPOS'].split(','))
+                if ciA[1] - ciA[0] > 200:
+                    ciA = map(int, var.info['CIPOS95'].split(','))
+                if ciB[1] - ciB[0] > 200:
+                    ciB = map(int, var2.info['CIPOS95'].split(','))
 
                 # infer the strands from the alt allele
                 if var.alt[-1] == '[' or var.alt[-1] == ']':
@@ -261,6 +265,10 @@ def sv_genotype(bam_string,
             # confidence intervals
             ciA = map(int, var.info['CIPOS'].split(','))
             ciB = map(int, var.info['CIEND'].split(','))
+            if ciA[1] - ciA[0] > 200:
+                ciA = map(int, var.info['CIPOS95'].split(','))
+            if ciB[1] - ciB[0] > 200:
+                ciB = map(int, var.info['CIEND95'].split(','))
             if svtype == 'DEL':
                 var_length = posB - posA
                 o1_is_reverse, o2_is_reverse =  False, True

--- a/svtyper/parsers.py
+++ b/svtyper/parsers.py
@@ -717,6 +717,9 @@ class Sample(object):
 # from a single molecule
 # ==================================================
 
+def rhash(r):
+    return hash((r.query_name, r.flag))
+
 class SamFragment(object):
     def __init__(self, read, lib):
         self.lib = lib
@@ -738,7 +741,7 @@ class SamFragment(object):
 
     def add_read(self, read):
         # ensure we don't add the same read twice
-        read_hash = read.__hash__()
+        read_hash = rhash(read)
         if read_hash in self.read_set:
             return
         else:


### PR DESCRIPTION
when the CI is large, we get a lot of very noisy calls. I just made a quick change and PR for discussion. I will evaluate this in smoove to see how performance changes. I can already see it removes about 20% of calls in my test case. The distribution goes from:
```
     26 BND
      8 DEL
    347 DUP
    185 INV
```
to:
```
     26 BND
      4 DEL
    254 DUP
    184 INV
```
I think the intuition is obvious, but just in case... when the CI gets too large, the genotyping just picks up a ton of noise and makes bad calls. In fact, I think that, given the slop that's already used, it might be good to try using CI95 exclusively. Any problems with this?

I will evaluate more thoroughly, but wanted to see if @ernfrid or any Hall lab folks (or @ryanlayer) had some thoughts on this.