### PR TITLE
Port code to python3 and add parallelization per individual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,13 @@ Thumbs.db
 #########################
 **__pycache__
 **.pyc
+.pytest_cache
+
+# Eggs #
+########
+.eggs
+svtyper.egg-info
+
+# Idea #
+########
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@
 Icon?
 ehthumbs.db
 Thumbs.db
+
+# Python compiled files #
+#########################
+**__pycache__
+**.pyc

--- a/scripts/update_info.py
+++ b/scripts/update_info.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
 import pysam
-import argparse, sys
-import math, time, re
+import argparse
+import sys
+import math
+import time
+import re
 from collections import Counter
 from argparse import RawTextHelpFormatter
 
@@ -13,13 +16,15 @@ __date__ = "$Date: 2015-09-27 09:31 $"
 # --------------------------------------
 # define functions
 
+
 def get_args():
     parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter, description="\
 update_info.py\n\
 author: " + __author__ + "\n\
 version: " + __version__ + "\n\
 description: Update the PE SR fields after SVTyper")
-    parser.add_argument(metavar='vcf', dest='input_vcf', nargs='?', type=argparse.FileType('r'), default=None, help='VCF input (default: stdin)')
+    parser.add_argument(metavar='vcf', dest='input_vcf', nargs='?',
+                        type=argparse.FileType('r'), default=None, help='VCF input (default: stdin)')
 
     # parse the arguments
     args = parser.parse_args()
@@ -34,7 +39,9 @@ description: Update the PE SR fields after SVTyper")
     # send back the user input
     return args
 
+
 class Vcf(object):
+
     def __init__(self):
         self.file_format = 'VCFv4.2'
         # self.fasta = fasta
@@ -52,15 +59,15 @@ class Vcf(object):
             elif line.split('=')[0] == '##reference':
                 self.reference = line.rstrip().split('=')[1]
             elif line.split('=')[0] == '##INFO':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_info(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##ALT':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_alt(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##FORMAT':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_format(*[b.split('=')[1] for b in r.findall(a)])
             elif line[0] == '#' and line[1] != '#':
@@ -71,10 +78,10 @@ class Vcf(object):
         if include_samples:
             header = '\n'.join(['##fileformat=' + self.file_format,
                                 '##fileDate=' + time.strftime('%Y%m%d'),
-                                '##reference=' + self.reference] + \
-                               [i.hstring for i in self.info_list] + \
-                               [a.hstring for a in self.alt_list] + \
-                               [f.hstring for f in self.format_list] + \
+                                '##reference=' + self.reference] +
+                               [i.hstring for i in self.info_list] +
+                               [a.hstring for a in self.alt_list] +
+                               [f.hstring for f in self.format_list] +
                                ['\t'.join([
                                    '#CHROM',
                                    'POS',
@@ -84,16 +91,16 @@ class Vcf(object):
                                    'QUAL',
                                    'FILTER',
                                    'INFO',
-                                   'FORMAT'] + \
-                                          self.sample_list
-                                      )])
+                                   'FORMAT'] +
+                                self.sample_list
+                                )])
         else:
             header = '\n'.join(['##fileformat=' + self.file_format,
                                 '##fileDate=' + time.strftime('%Y%m%d'),
-                                '##reference=' + self.reference] + \
-                               [i.hstring for i in self.info_list] + \
-                               [a.hstring for a in self.alt_list] + \
-                               [f.hstring for f in self.format_list] + \
+                                '##reference=' + self.reference] +
+                               [i.hstring for i in self.info_list] +
+                               [a.hstring for a in self.alt_list] +
+                               [f.hstring for f in self.format_list] +
                                ['\t'.join([
                                    '#CHROM',
                                    'POS',
@@ -103,7 +110,7 @@ class Vcf(object):
                                    'QUAL',
                                    'FILTER',
                                    'INFO']
-                                          )])
+                               )])
         return header
 
     def add_info(self, id, number, type, desc):
@@ -136,6 +143,7 @@ class Vcf(object):
         return self.sample_list.index(sample) + 9
 
     class Info(object):
+
         def __init__(self, id, number, type, desc):
             self.id = str(id)
             self.number = str(number)
@@ -144,18 +152,22 @@ class Vcf(object):
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##INFO=<ID=' + self.id + ',Number=' + self.number + ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##INFO=<ID=' + self.id + ',Number=' + self.number + \
+                ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
 
     class Alt(object):
+
         def __init__(self, id, desc):
             self.id = str(id)
             self.desc = str(desc)
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##ALT=<ID=' + self.id + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##ALT=<ID=' + self.id + \
+                ',Description=\"' + self.desc + '\">'
 
     class Format(object):
+
         def __init__(self, id, number, type, desc):
             self.id = str(id)
             self.number = str(number)
@@ -164,9 +176,12 @@ class Vcf(object):
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##FORMAT=<ID=' + self.id + ',Number=' + self.number + ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##FORMAT=<ID=' + self.id + ',Number=' + self.number + \
+                ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+
 
 class Variant(object):
+
     def __init__(self, var_list, vcf):
         self.chrom = var_list[0]
         self.pos = int(var_list[1])
@@ -184,10 +199,11 @@ class Variant(object):
         self.format_list = vcf.format_list
         self.active_formats = list()
         self.gts = dict()
-        
+
         # fill in empty sample genotypes
         if len(var_list) < 8:
-            sys.stderr.write('\nError: VCF file must have at least 8 columns\n')
+            sys.stderr.write(
+                '\nError: VCF file must have at least 8 columns\n')
             exit(1)
         if len(var_list) < 9:
             var_list.append("GT")
@@ -204,7 +220,8 @@ class Variant(object):
                 self.gts[s] = Genotype(self, s, './.')
 
         self.info = dict()
-        i_split = [a.split('=') for a in var_list[7].split(';')] # temp list of split info column
+        i_split = [a.split('=')
+                   for a in var_list[7].split(';')]  # temp list of split info column
         for i in i_split:
             if len(i) == 1:
                 i.append(True)
@@ -214,7 +231,8 @@ class Variant(object):
         if field in [i.id for i in self.info_list]:
             self.info[field] = value
         else:
-            sys.stderr.write('\nError: invalid INFO field, \"' + field + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid INFO field, \"' + field + '\"\n')
             exit(1)
 
     def get_info(self, field):
@@ -223,11 +241,12 @@ class Variant(object):
     def get_info_string(self):
         i_list = list()
         for info_field in self.info_list:
-            if info_field.id in self.info.keys():
+            if info_field.id in list(self.info.keys()):
                 if info_field.type == 'Flag':
                     i_list.append(info_field.id)
                 else:
-                    i_list.append('%s=%s' % (info_field.id, self.info[info_field.id]))
+                    i_list.append(
+                        '%s=%s' % (info_field.id, self.info[info_field.id]))
         return ';'.join(i_list)
 
     def get_format_string(self):
@@ -241,10 +260,11 @@ class Variant(object):
         if sample_name in self.sample_list:
             return self.gts[sample_name]
         else:
-            sys.stderr.write('\nError: invalid sample name, \"' + sample_name + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid sample name, \"' + sample_name + '\"\n')
 
     def get_var_string(self):
-        s = '\t'.join(map(str,[
+        s = '\t'.join(map(str, [
             self.chrom,
             self.pos,
             self.var_id,
@@ -254,11 +274,14 @@ class Variant(object):
             self.filter,
             self.get_info_string(),
             self.get_format_string(),
-            '\t'.join(self.genotype(s).get_gt_string() for s in self.sample_list)
+            '\t'.join(self.genotype(s).get_gt_string()
+                      for s in self.sample_list)
         ]))
         return s
 
+
 class Genotype(object):
+
     def __init__(self, variant, sample_name, gt):
         self.format = dict()
         self.variant = variant
@@ -270,9 +293,11 @@ class Genotype(object):
             if field not in self.variant.active_formats:
                 self.variant.active_formats.append(field)
                 # sort it to be in the same order as the format_list in header
-                self.variant.active_formats.sort(key=lambda x: [f.id for f in self.variant.format_list].index(x))
+                self.variant.active_formats.sort(
+                    key=lambda x: [f.id for f in self.variant.format_list].index(x))
         else:
-            sys.stderr.write('\nError: invalid FORMAT field, \"' + field + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid FORMAT field, \"' + field + '\"\n')
             exit(1)
 
     def get_format(self, field):
@@ -288,13 +313,16 @@ class Genotype(object):
                     g_list.append(self.format[f])
             else:
                 g_list.append('.')
-        return ':'.join(map(str,g_list))
+        return ':'.join(map(str, g_list))
 
 # primary function
+
+
 def update_info(vcf_file):
     in_header = True
     header = []
-    breakend_dict = {} # cache to hold unmatched generic breakends for genotyping
+    breakend_dict = {}
+        # cache to hold unmatched generic breakends for genotyping
     vcf = Vcf()
     vcf_out = sys.stdout
 
@@ -302,14 +330,15 @@ def update_info(vcf_file):
     for line in vcf_file:
         if in_header:
             if line[0] == '#':
-                header.append(line) 
+                header.append(line)
                 if line[1] != '#':
                     vcf_samples = line.rstrip().split('\t')[9:]
                 continue
             else:
                 in_header = False
                 vcf.add_header(header)
-                vcf.add_info('MSQ', '1', 'Float', 'Mean sample quality of positively genotyped samples')
+                vcf.add_info(
+                    'MSQ', '1', 'Float', 'Mean sample quality of positively genotyped samples')
                 vcf.remove_info('SNAME')
 
                 # write the output header
@@ -350,11 +379,12 @@ def update_info(vcf_file):
 
         vcf_out.write(var.get_var_string() + '\n')
     vcf_out.close()
-    
+
     return
 
 # --------------------------------------
 # main function
+
 
 def main():
     # parse the command line args
@@ -370,6 +400,6 @@ def main():
 if __name__ == '__main__':
     try:
         sys.exit(main())
-    except IOError, e:
+    except IOError as e:
         if e.errno != 32:  # ignore SIGPIPE
-            raise 
+            raise

--- a/scripts/vcf_allele_freq.py
+++ b/scripts/vcf_allele_freq.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
 import pysam
-import argparse, sys
-import math, time, re
+import argparse
+import sys
+import math
+import time
+import re
 from collections import Counter
 from argparse import RawTextHelpFormatter
 
@@ -13,13 +16,15 @@ __date__ = "$Date: 2015-04-22 09:31 $"
 # --------------------------------------
 # define functions
 
+
 def get_args():
     parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter, description="\
 vcf_allele_freq.py\n\
 author: " + __author__ + "\n\
 version: " + __version__ + "\n\
 description: Add allele frequency information to a VCF file")
-    parser.add_argument(metavar='vcf', dest='input_vcf', nargs='?', type=argparse.FileType('r'), default=None, help='VCF input (default: stdin)')
+    parser.add_argument(metavar='vcf', dest='input_vcf', nargs='?',
+                        type=argparse.FileType('r'), default=None, help='VCF input (default: stdin)')
 
     # parse the arguments
     args = parser.parse_args()
@@ -34,7 +39,9 @@ description: Add allele frequency information to a VCF file")
     # send back the user input
     return args
 
+
 class Vcf(object):
+
     def __init__(self):
         self.file_format = 'VCFv4.2'
         # self.fasta = fasta
@@ -53,19 +60,19 @@ class Vcf(object):
             elif line.split('=')[0] == '##reference':
                 self.reference = line.rstrip().split('=')[1]
             elif line.split('=')[0] == '##INFO':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_info(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##ALT':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_alt(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##FORMAT':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_format(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##FILTER':
-                a = line[line.find('<')+1:-2]
+                a = line[line.find('<') + 1:-2]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_filter(*[b.split('=')[1] for b in r.findall(a)])
             elif line[0] == '#' and line[1] != '#':
@@ -76,11 +83,11 @@ class Vcf(object):
         if include_samples:
             header = '\n'.join(['##fileformat=' + self.file_format,
                                 '##fileDate=' + time.strftime('%Y%m%d'),
-                                '##reference=' + self.reference] + \
-                               [f.hstring for f in self.filter_list] + \
-                               [i.hstring for i in self.info_list] + \
-                               [a.hstring for a in self.alt_list] + \
-                               [f.hstring for f in self.format_list] + \
+                                '##reference=' + self.reference] +
+                               [f.hstring for f in self.filter_list] +
+                               [i.hstring for i in self.info_list] +
+                               [a.hstring for a in self.alt_list] +
+                               [f.hstring for f in self.format_list] +
                                ['\t'.join([
                                    '#CHROM',
                                    'POS',
@@ -90,17 +97,17 @@ class Vcf(object):
                                    'QUAL',
                                    'FILTER',
                                    'INFO',
-                                   'FORMAT'] + \
-                                          self.sample_list
-                                      )])
+                                   'FORMAT'] +
+                                self.sample_list
+                                )])
         else:
             header = '\n'.join(['##fileformat=' + self.file_format,
                                 '##fileDate=' + time.strftime('%Y%m%d'),
-                                '##reference=' + self.reference] + \
-                               [f.hstring for f in self.filter_list] + \
-                               [i.hstring for i in self.info_list] + \
-                               [a.hstring for a in self.alt_list] + \
-                               [f.hstring for f in self.format_list] + \
+                                '##reference=' + self.reference] +
+                               [f.hstring for f in self.filter_list] +
+                               [i.hstring for i in self.info_list] +
+                               [a.hstring for a in self.alt_list] +
+                               [f.hstring for f in self.format_list] +
                                ['\t'.join([
                                    '#CHROM',
                                    'POS',
@@ -110,7 +117,7 @@ class Vcf(object):
                                    'QUAL',
                                    'FILTER',
                                    'INFO']
-                                          )])
+                               )])
         return header
 
     def add_info(self, id, number, type, desc):
@@ -142,6 +149,7 @@ class Vcf(object):
         return self.sample_list.index(sample) + 9
 
     class Info(object):
+
         def __init__(self, id, number, type, desc):
             self.id = str(id)
             self.number = str(number)
@@ -150,18 +158,22 @@ class Vcf(object):
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##INFO=<ID=' + self.id + ',Number=' + self.number + ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##INFO=<ID=' + self.id + ',Number=' + self.number + \
+                ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
 
     class Alt(object):
+
         def __init__(self, id, desc):
             self.id = str(id)
             self.desc = str(desc)
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##ALT=<ID=' + self.id + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##ALT=<ID=' + self.id + \
+                ',Description=\"' + self.desc + '\">'
 
     class Format(object):
+
         def __init__(self, id, number, type, desc):
             self.id = str(id)
             self.number = str(number)
@@ -170,18 +182,23 @@ class Vcf(object):
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##FORMAT=<ID=' + self.id + ',Number=' + self.number + ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##FORMAT=<ID=' + self.id + ',Number=' + self.number + \
+                ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
 
     class Filter(object):
+
         def __init__(self, id, desc):
             self.id = str(id)
             self.desc = str(desc)
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##FILTER=<ID=' + self.id + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##FILTER=<ID=' + self.id + \
+                ',Description=\"' + self.desc + '\">'
+
 
 class Variant(object):
+
     def __init__(self, var_list, vcf):
         self.chrom = var_list[0]
         self.pos = int(var_list[1])
@@ -199,10 +216,11 @@ class Variant(object):
         self.format_list = vcf.format_list
         self.active_formats = list()
         self.gts = dict()
-        
+
         # fill in empty sample genotypes
         if len(var_list) < 8:
-            sys.stderr.write('\nError: VCF file must have at least 8 columns\n')
+            sys.stderr.write(
+                '\nError: VCF file must have at least 8 columns\n')
             exit(1)
         if len(var_list) < 9:
             var_list.append("GT")
@@ -219,7 +237,8 @@ class Variant(object):
                 self.gts[s] = Genotype(self, s, './.')
 
         self.info = dict()
-        i_split = [a.split('=') for a in var_list[7].split(';')] # temp list of split info column
+        i_split = [a.split('=')
+                   for a in var_list[7].split(';')]  # temp list of split info column
         for i in i_split:
             if len(i) == 1:
                 i.append(True)
@@ -229,7 +248,8 @@ class Variant(object):
         if field in [i.id for i in self.info_list]:
             self.info[field] = value
         else:
-            sys.stderr.write('\nError: invalid INFO field, \"' + field + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid INFO field, \"' + field + '\"\n')
             exit(1)
 
     def get_info(self, field):
@@ -238,11 +258,12 @@ class Variant(object):
     def get_info_string(self):
         i_list = list()
         for info_field in self.info_list:
-            if info_field.id in self.info.keys():
+            if info_field.id in list(self.info.keys()):
                 if info_field.type == 'Flag':
                     i_list.append(info_field.id)
                 else:
-                    i_list.append('%s=%s' % (info_field.id, self.info[info_field.id]))
+                    i_list.append(
+                        '%s=%s' % (info_field.id, self.info[info_field.id]))
         return ';'.join(i_list)
 
     def get_format_string(self):
@@ -256,11 +277,12 @@ class Variant(object):
         if sample_name in self.sample_list:
             return self.gts[sample_name]
         else:
-            sys.stderr.write('\nError: invalid sample name, \"' + sample_name + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid sample name, \"' + sample_name + '\"\n')
 
     def get_var_string(self):
         if len(self.active_formats) == 0:
-            s = '\t'.join(map(str,[
+            s = '\t'.join(map(str, [
                 self.chrom,
                 self.pos,
                 self.var_id,
@@ -271,7 +293,7 @@ class Variant(object):
                 self.get_info_string()
             ]))
         else:
-            s = '\t'.join(map(str,[
+            s = '\t'.join(map(str, [
                 self.chrom,
                 self.pos,
                 self.var_id,
@@ -281,11 +303,14 @@ class Variant(object):
                 self.filter,
                 self.get_info_string(),
                 self.get_format_string(),
-                '\t'.join(self.genotype(s).get_gt_string() for s in self.sample_list)
+                '\t'.join(self.genotype(s).get_gt_string()
+                          for s in self.sample_list)
             ]))
         return s
 
+
 class Genotype(object):
+
     def __init__(self, variant, sample_name, gt):
         self.format = dict()
         self.variant = variant
@@ -297,9 +322,11 @@ class Genotype(object):
             if field not in self.variant.active_formats:
                 self.variant.active_formats.append(field)
                 # sort it to be in the same order as the format_list in header
-                self.variant.active_formats.sort(key=lambda x: [f.id for f in self.variant.format_list].index(x))
+                self.variant.active_formats.sort(
+                    key=lambda x: [f.id for f in self.variant.format_list].index(x))
         else:
-            sys.stderr.write('\nError: invalid FORMAT field, \"' + field + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid FORMAT field, \"' + field + '\"\n')
             exit(1)
 
     def get_format(self, field):
@@ -315,13 +342,16 @@ class Genotype(object):
                     g_list.append(self.format[f])
             else:
                 g_list.append('.')
-        return ':'.join(map(str,g_list))
+        return ':'.join(map(str, g_list))
 
 # primary function
+
+
 def add_af(vcf_file):
     in_header = True
     header = []
-    breakend_dict = {} # cache to hold unmatched generic breakends for genotyping
+    breakend_dict = {}
+        # cache to hold unmatched generic breakends for genotyping
     vcf = Vcf()
     vcf_out = sys.stdout
 
@@ -329,7 +359,7 @@ def add_af(vcf_file):
     for line in vcf_file:
         if in_header:
             if line.startswith('##'):
-                header.append(line) 
+                header.append(line)
                 continue
             elif line.startswith('#CHROM'):
                 v = line.rstrip().split('\t')
@@ -337,9 +367,11 @@ def add_af(vcf_file):
 
                 in_header = False
                 vcf.add_header(header)
-                
-                vcf.add_info('AF', 'A', 'Float', 'Allele Frequency, for each ALT allele, in the same order as listed')
-                vcf.add_info('NSAMP', '1', 'Integer', 'Number of samples with non-reference genotypes')
+
+                vcf.add_info(
+                    'AF', 'A', 'Float', 'Allele Frequency, for each ALT allele, in the same order as listed')
+                vcf.add_info(
+                    'NSAMP', '1', 'Integer', 'Number of samples with non-reference genotypes')
 
                 # write header
                 vcf_out.write(vcf.get_header(include_samples=False))
@@ -354,17 +386,17 @@ def add_af(vcf_file):
         alleles = [0] * (num_alt + 1)
         num_samp = 0
 
-        for i in xrange(9,len(v)):
+        for i in range(9, len(v)):
             gt_string = v[i].split(':')[0]
 
-            if '.' in  gt_string:
+            if '.' in gt_string:
                 continue
             gt = gt_string.split('/')
             if len(gt) == 1:
                 gt = gt_string.split('|')
-            gt = map(int, gt)
+            gt = list(map(int, gt))
 
-            for i in xrange(len(gt)):
+            for i in range(len(gt)):
                 alleles[gt[i]] += 1
 
             # iterate the number of non-reference samples
@@ -376,12 +408,13 @@ def add_af(vcf_file):
 
         # populate AF
         if allele_sum > 0:
-            for i in xrange(len(alleles)):
+            for i in range(len(alleles)):
                 allele_freq[i] = alleles[i] / allele_sum
-            var.info['AF'] = ','.join(map(str, ['%.4g' % a for a in allele_freq[1:]]))
+            var.info['AF'] = ','.join(
+                map(str, ['%.4g' % a for a in allele_freq[1:]]))
         else:
             var.info['AF'] = ','.join(map(str, allele_freq[1:]))
-        
+
         # populate NSAMP
         var.info['NSAMP'] = num_samp
 
@@ -391,11 +424,12 @@ def add_af(vcf_file):
                       + '\t'.join(v[8:])
                       + '\n')
     vcf_out.close()
-    
+
     return
 
 # --------------------------------------
 # main function
+
 
 def main():
     # parse the command line args
@@ -411,6 +445,6 @@ def main():
 if __name__ == '__main__':
     try:
         sys.exit(main())
-    except IOError, e:
+    except IOError as e:
         if e.errno != 32:  # ignore SIGPIPE
-            raise 
+            raise

--- a/scripts/vcf_group_multiline.py
+++ b/scripts/vcf_group_multiline.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
 import pysam
-import argparse, sys
-import math, time, re
+import argparse
+import sys
+import math
+import time
+import re
 from collections import Counter
 from argparse import RawTextHelpFormatter
 
@@ -13,13 +16,15 @@ __date__ = "$Date: 2015-04-22 09:31 $"
 # --------------------------------------
 # define functions
 
+
 def get_args():
     parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter, description="\
 vcf_group_multiline.py\n\
 author: " + __author__ + "\n\
 version: " + __version__ + "\n\
 description: Group multiline variants prior vcf_paste.py")
-    parser.add_argument(metavar='vcf', dest='input_vcf', nargs='?', type=argparse.FileType('r'), default=None, help='VCF input (default: stdin)')
+    parser.add_argument(metavar='vcf', dest='input_vcf', nargs='?',
+                        type=argparse.FileType('r'), default=None, help='VCF input (default: stdin)')
 
     # parse the arguments
     args = parser.parse_args()
@@ -34,7 +39,9 @@ description: Group multiline variants prior vcf_paste.py")
     # send back the user input
     return args
 
+
 class Vcf(object):
+
     def __init__(self):
         self.file_format = 'VCFv4.2'
         # self.fasta = fasta
@@ -52,15 +59,15 @@ class Vcf(object):
             elif line.split('=')[0] == '##reference':
                 self.reference = line.rstrip().split('=')[1]
             elif line.split('=')[0] == '##INFO':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_info(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##ALT':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_alt(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##FORMAT':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_format(*[b.split('=')[1] for b in r.findall(a)])
             elif line[0] == '#' and line[1] != '#':
@@ -71,10 +78,10 @@ class Vcf(object):
         if include_samples:
             header = '\n'.join(['##fileformat=' + self.file_format,
                                 '##fileDate=' + time.strftime('%Y%m%d'),
-                                '##reference=' + self.reference] + \
-                               [i.hstring for i in self.info_list] + \
-                               [a.hstring for a in self.alt_list] + \
-                               [f.hstring for f in self.format_list] + \
+                                '##reference=' + self.reference] +
+                               [i.hstring for i in self.info_list] +
+                               [a.hstring for a in self.alt_list] +
+                               [f.hstring for f in self.format_list] +
                                ['\t'.join([
                                    '#CHROM',
                                    'POS',
@@ -84,16 +91,16 @@ class Vcf(object):
                                    'QUAL',
                                    'FILTER',
                                    'INFO',
-                                   'FORMAT'] + \
-                                          self.sample_list
-                                      )])
+                                   'FORMAT'] +
+                                self.sample_list
+                                )])
         else:
             header = '\n'.join(['##fileformat=' + self.file_format,
                                 '##fileDate=' + time.strftime('%Y%m%d'),
-                                '##reference=' + self.reference] + \
-                               [i.hstring for i in self.info_list] + \
-                               [a.hstring for a in self.alt_list] + \
-                               [f.hstring for f in self.format_list] + \
+                                '##reference=' + self.reference] +
+                               [i.hstring for i in self.info_list] +
+                               [a.hstring for a in self.alt_list] +
+                               [f.hstring for f in self.format_list] +
                                ['\t'.join([
                                    '#CHROM',
                                    'POS',
@@ -103,7 +110,7 @@ class Vcf(object):
                                    'QUAL',
                                    'FILTER',
                                    'INFO']
-                                          )])
+                               )])
         return header
 
     def add_info(self, id, number, type, desc):
@@ -130,6 +137,7 @@ class Vcf(object):
         return self.sample_list.index(sample) + 9
 
     class Info(object):
+
         def __init__(self, id, number, type, desc):
             self.id = str(id)
             self.number = str(number)
@@ -138,18 +146,22 @@ class Vcf(object):
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##INFO=<ID=' + self.id + ',Number=' + self.number + ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##INFO=<ID=' + self.id + ',Number=' + self.number + \
+                ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
 
     class Alt(object):
+
         def __init__(self, id, desc):
             self.id = str(id)
             self.desc = str(desc)
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##ALT=<ID=' + self.id + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##ALT=<ID=' + self.id + \
+                ',Description=\"' + self.desc + '\">'
 
     class Format(object):
+
         def __init__(self, id, number, type, desc):
             self.id = str(id)
             self.number = str(number)
@@ -158,9 +170,12 @@ class Vcf(object):
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##FORMAT=<ID=' + self.id + ',Number=' + self.number + ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##FORMAT=<ID=' + self.id + ',Number=' + self.number + \
+                ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+
 
 class Variant(object):
+
     def __init__(self, var_list, vcf):
         self.chrom = var_list[0]
         self.pos = int(var_list[1])
@@ -178,10 +193,11 @@ class Variant(object):
         self.format_list = vcf.format_list
         self.active_formats = list()
         self.gts = dict()
-        
+
         # fill in empty sample genotypes
         if len(var_list) < 8:
-            sys.stderr.write('\nError: VCF file must have at least 8 columns\n')
+            sys.stderr.write(
+                '\nError: VCF file must have at least 8 columns\n')
             exit(1)
         if len(var_list) < 9:
             var_list.append("GT")
@@ -198,7 +214,8 @@ class Variant(object):
                 self.gts[s] = Genotype(self, s, './.')
 
         self.info = dict()
-        i_split = [a.split('=') for a in var_list[7].split(';')] # temp list of split info column
+        i_split = [a.split('=')
+                   for a in var_list[7].split(';')]  # temp list of split info column
         for i in i_split:
             if len(i) == 1:
                 i.append(True)
@@ -208,7 +225,8 @@ class Variant(object):
         if field in [i.id for i in self.info_list]:
             self.info[field] = value
         else:
-            sys.stderr.write('\nError: invalid INFO field, \"' + field + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid INFO field, \"' + field + '\"\n')
             exit(1)
 
     def get_info(self, field):
@@ -217,11 +235,12 @@ class Variant(object):
     def get_info_string(self):
         i_list = list()
         for info_field in self.info_list:
-            if info_field.id in self.info.keys():
+            if info_field.id in list(self.info.keys()):
                 if info_field.type == 'Flag':
                     i_list.append(info_field.id)
                 else:
-                    i_list.append('%s=%s' % (info_field.id, self.info[info_field.id]))
+                    i_list.append(
+                        '%s=%s' % (info_field.id, self.info[info_field.id]))
         return ';'.join(i_list)
 
     def get_format_string(self):
@@ -235,10 +254,11 @@ class Variant(object):
         if sample_name in self.sample_list:
             return self.gts[sample_name]
         else:
-            sys.stderr.write('\nError: invalid sample name, \"' + sample_name + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid sample name, \"' + sample_name + '\"\n')
 
     def get_var_string(self):
-        s = '\t'.join(map(str,[
+        s = '\t'.join(map(str, [
             self.chrom,
             self.pos,
             self.var_id,
@@ -248,11 +268,14 @@ class Variant(object):
             self.filter,
             self.get_info_string(),
             self.get_format_string(),
-            '\t'.join(self.genotype(s).get_gt_string() for s in self.sample_list)
+            '\t'.join(self.genotype(s).get_gt_string()
+                      for s in self.sample_list)
         ]))
         return s
 
+
 class Genotype(object):
+
     def __init__(self, variant, sample_name, gt):
         self.format = dict()
         self.variant = variant
@@ -264,9 +287,11 @@ class Genotype(object):
             if field not in self.variant.active_formats:
                 self.variant.active_formats.append(field)
                 # sort it to be in the same order as the format_list in header
-                self.variant.active_formats.sort(key=lambda x: [f.id for f in self.variant.format_list].index(x))
+                self.variant.active_formats.sort(
+                    key=lambda x: [f.id for f in self.variant.format_list].index(x))
         else:
-            sys.stderr.write('\nError: invalid FORMAT field, \"' + field + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid FORMAT field, \"' + field + '\"\n')
             exit(1)
 
     def get_format(self, field):
@@ -282,13 +307,16 @@ class Genotype(object):
                     g_list.append(self.format[f])
             else:
                 g_list.append('.')
-        return ':'.join(map(str,g_list))
+        return ':'.join(map(str, g_list))
 
 # primary function
+
+
 def sv_genotype(vcf_file):
     in_header = True
     header = []
-    breakend_dict = {} # cache to hold unmatched generic breakends for genotyping
+    breakend_dict = {}
+        # cache to hold unmatched generic breakends for genotyping
     vcf = Vcf()
     vcf_out = sys.stdout
 
@@ -296,7 +324,7 @@ def sv_genotype(vcf_file):
     for line in vcf_file:
         if in_header:
             if line[0] == '#':
-                header.append(line) 
+                header.append(line)
                 if line[1] != '#':
                     vcf_samples = line.rstrip().split('\t')[9:]
                 continue
@@ -305,19 +333,29 @@ def sv_genotype(vcf_file):
                 vcf.add_header(header)
                 # if detailed:
                 vcf.add_format('GQ', 1, 'Float', 'Genotype quality')
-                vcf.add_format('SQ', 1, 'Float', 'Phred-scaled probability that this site is variant (non-reference in this sample')
+                vcf.add_format(
+                    'SQ', 1, 'Float', 'Phred-scaled probability that this site is variant (non-reference in this sample')
                 vcf.add_format('GL', 'G', 'Float', 'Genotype Likelihood, log10-scaled likelihoods of the data given the called genotype for each possible gen\
 otype generated from the reference and alternate alleles given the sample ploidy')
                 vcf.add_format('DP', 1, 'Integer', 'Read depth')
-                vcf.add_format('RO', 1, 'Integer', 'Reference allele observation count, with partial observations recorded fractionally')
-                vcf.add_format('AO', 'A', 'Integer', 'Alternate allele observations, with partial observations recorded fractionally')
-                vcf.add_format('QR', 1, 'Integer', 'Sum of quality of reference observations')
-                vcf.add_format('QA', 'A', 'Integer', 'Sum of quality of alternate observations')
-                vcf.add_format('RS', 1, 'Integer', 'Reference allele split-read observation count, with partial observations recorded fractionally')
-                vcf.add_format('AS', 'A', 'Integer', 'Alternate allele split-read observation count, with partial observations recorded fractionally')
-                vcf.add_format('RP', 1, 'Integer', 'Reference allele paired-end observation count, with partial observations recorded fractionally')
-                vcf.add_format('AP', 'A', 'Integer', 'Alternate allele paired-end observation count, with partial observations recorded fractionally')
-                vcf.add_format('AB', 'A', 'Float', 'Allele balance, fraction of observations from alternate allele, QA/(QR+QA)')
+                vcf.add_format(
+                    'RO', 1, 'Integer', 'Reference allele observation count, with partial observations recorded fractionally')
+                vcf.add_format(
+                    'AO', 'A', 'Integer', 'Alternate allele observations, with partial observations recorded fractionally')
+                vcf.add_format(
+                    'QR', 1, 'Integer', 'Sum of quality of reference observations')
+                vcf.add_format(
+                    'QA', 'A', 'Integer', 'Sum of quality of alternate observations')
+                vcf.add_format(
+                    'RS', 1, 'Integer', 'Reference allele split-read observation count, with partial observations recorded fractionally')
+                vcf.add_format(
+                    'AS', 'A', 'Integer', 'Alternate allele split-read observation count, with partial observations recorded fractionally')
+                vcf.add_format(
+                    'RP', 1, 'Integer', 'Reference allele paired-end observation count, with partial observations recorded fractionally')
+                vcf.add_format(
+                    'AP', 'A', 'Integer', 'Alternate allele paired-end observation count, with partial observations recorded fractionally')
+                vcf.add_format(
+                    'AB', 'A', 'Float', 'Allele balance, fraction of observations from alternate allele, QA/(QR+QA)')
 
                 # write the output header
                 if len(vcf_samples) > 0:
@@ -329,7 +367,7 @@ otype generated from the reference and alternate alleles given the sample ploidy
         var = Variant(v, vcf)
 
         # genotype generic breakends
-        if var.info['SVTYPE']=='BND':
+        if var.info['SVTYPE'] == 'BND':
             if var.info['MATEID'] in breakend_dict:
                 var2 = var
                 var = breakend_dict[var.info['MATEID']]
@@ -338,16 +376,20 @@ otype generated from the reference and alternate alleles given the sample ploidy
                 posA = var.pos
                 posB = var2.pos
                 # confidence intervals
-                ciA = [posA + ci for ci in map(int, var.info['CIPOS'].split(','))]
-                ciB = [posB + ci for ci in map(int, var2.info['CIPOS'].split(','))]
+                ciA = [posA + ci for ci in map(
+                    int, var.info['CIPOS'].split(','))]
+                ciB = [posB + ci for ci in map(
+                    int, var2.info['CIPOS'].split(','))]
 
                 # infer the strands from the alt allele
                 if var.alt[-1] == '[' or var.alt[-1] == ']':
                     o1 = '+'
-                else: o1 = '-'
+                else:
+                    o1 = '-'
                 if var2.alt[-1] == '[' or var2.alt[-1] == ']':
                     o2 = '+'
-                else: o2 = '-'
+                else:
+                    o2 = '-'
             else:
                 breakend_dict[var.var_id] = var
                 continue
@@ -360,23 +402,23 @@ otype generated from the reference and alternate alleles given the sample ploidy
             ciA = [posA + ci for ci in map(int, var.info['CIPOS'].split(','))]
             ciB = [posB + ci for ci in map(int, var.info['CIEND'].split(','))]
             if var.get_info('SVTYPE') == 'DEL':
-                o1, o2 =  '+', '-'
+                o1, o2 = '+', '-'
             elif var.get_info('SVTYPE') == 'DUP':
-                o1, o2 =  '-', '+'
+                o1, o2 = '-', '+'
             elif var.get_info('SVTYPE') == 'INV':
-                o1, o2 =  '+', '+'
+                o1, o2 = '+', '+'
 
-        # # increment the negative strand values (note position in VCF should be the base immediately left of the breakpoint junction)
+        # increment the negative strand values (note position in VCF should be the base immediately left of the breakpoint junction)
         # if o1 == '-': posA += 1
         # if o2 == '-': posB += 1
-        # # if debug: print posA, posB
+        # if debug: print posA, posB
 
-        # # for i in xrange(len(bam_list)):
+        # for i in xrange(len(bam_list)):
         # for sample in sample_list:
         #     '''
         #     Breakend A
         #     '''
-        #     # Count splitters
+        # Count splitters
         #     ref_counter_a = Counter()
         #     spl_counter_a = Counter()
         #     ref_scaled_counter_a = Counter()
@@ -391,15 +433,16 @@ otype generated from the reference and alternate alleles given the sample ploidy
         #     for spl_read in sample.spl_bam.fetch(chromA, max(posA - padding, 0), posA + padding + 1):
         #         if not spl_read.is_duplicate and not spl_read.is_unmapped:
         #             if o1 == '+' and spl_read.cigar[0][0] == 0:
-        #                 # if debug: print 'o1+', spl_read.aend
+        # if debug: print 'o1+', spl_read.aend
         #                 spl_counter_a[spl_read.aend] += 1
         #                 spl_scaled_counter_a[spl_read.aend] += (1-10**(-spl_read.mapq/10.0))
         #             elif o1 == '-' and spl_read.cigar[-1][0] == 0:
-        #                 # if debug: print 'o1-', spl_read.pos + 1
+        # if debug: print 'o1-', spl_read.pos + 1
         #                 spl_counter_a[spl_read.pos + 1] += 1
-        #                 spl_scaled_counter_a[spl_read.pos + 1] += (1-10**(-spl_read.mapq/10.0))
+        # spl_scaled_counter_a[spl_read.pos + 1] +=
+        # (1-10**(-spl_read.mapq/10.0))
 
-        #     # Count paired-end discordant and concordants
+        # Count paired-end discordant and concordants
         #     (conc_counter_a,
         #      disc_counter_a,
         #      conc_scaled_counter_a,
@@ -412,7 +455,7 @@ otype generated from the reference and alternate alleles given the sample ploidy
         #     '''
         #     Breakend B
         #     '''
-        #     # Count splitters
+        # Count splitters
         #     ref_counter_b = Counter()
         #     spl_counter_b = Counter()
         #     ref_scaled_counter_b = Counter()
@@ -428,25 +471,28 @@ otype generated from the reference and alternate alleles given the sample ploidy
         #         if not spl_read.is_duplicate and not spl_read.is_unmapped:
         #             if o2 == '+' and spl_read.cigar[0][0] == 0:
         #                 spl_counter_b[spl_read.aend] += 1
-        #                 # if debug: print 'o2+', spl_read.aend
+        # if debug: print 'o2+', spl_read.aend
         #                 spl_scaled_counter_b[spl_read.aend] += (1-10**(-spl_read.mapq/10.0))
         #             elif o2 == '-' and spl_read.cigar[-1][0] == 0:
-        #                 # if debug: print 'o2-', spl_read.pos + 1
+        # if debug: print 'o2-', spl_read.pos + 1
         #                 spl_counter_b[spl_read.pos + 1] += 1
-        #                 spl_scaled_counter_b[spl_read.pos + 1] += (1-10**(-spl_read.mapq/10.0))
-            
-        #     # tally up the splitters
+        # spl_scaled_counter_b[spl_read.pos + 1] +=
+        # (1-10**(-spl_read.mapq/10.0))
+
+        # tally up the splitters
         #     sr_ref_a = int(round(sum(ref_counter_a[p] for p in xrange(posA - split_slop, posA + split_slop + 1)) / float(2 * split_slop + 1)))
         #     sr_spl_a = sum(spl_counter_a[p] for p in xrange(posA-split_slop, posA+split_slop + 1))
         #     sr_ref_b = int(round(sum(ref_counter_b[p] for p in xrange(posB - split_slop, posB + split_slop + 1)) / float(2 * split_slop + 1)))
-        #     sr_spl_b = sum(spl_counter_b[p] for p in xrange(posB - split_slop, posB + split_slop + 1))
+        # sr_spl_b = sum(spl_counter_b[p] for p in xrange(posB - split_slop,
+        # posB + split_slop + 1))
 
         #     sr_ref_scaled_a = sum(ref_scaled_counter_a[p] for p in xrange(posA - split_slop, posA + split_slop + 1)) / float(2 * split_slop + 1)
         #     sr_spl_scaled_a = sum(spl_scaled_counter_a[p] for p in xrange(posA-split_slop, posA+split_slop + 1))
         #     sr_ref_scaled_b = sum(ref_scaled_counter_b[p] for p in xrange(posB - split_slop, posB + split_slop + 1)) / float(2 * split_slop + 1)
-        #     sr_spl_scaled_b = sum(spl_scaled_counter_b[p] for p in xrange(posB - split_slop, posB + split_slop + 1))
+        # sr_spl_scaled_b = sum(spl_scaled_counter_b[p] for p in xrange(posB -
+        # split_slop, posB + split_slop + 1))
 
-        #     # Count paired-end discordants and concordants
+        # Count paired-end discordants and concordants
         #     (conc_counter_b,
         #      disc_counter_b,
         #      conc_scaled_counter_b,
@@ -466,10 +512,11 @@ otype generated from the reference and alternate alleles given the sample ploidy
         #         print 'sr_a_scaled', '(ref, alt)', sr_ref_scaled_a, sr_spl_scaled_a
         #         print 'pe_a_scaled', '(ref, alt)', conc_scaled_counter_a, disc_scaled_counter_a
         #         print 'sr_b_scaled', '(ref, alt)', sr_ref_scaled_b, sr_spl_scaled_b
-        #         print 'pe_b_scaled', '(ref, alt)', conc_scaled_counter_b, disc_scaled_counter_b
+        # print 'pe_b_scaled', '(ref, alt)', conc_scaled_counter_b,
+        # disc_scaled_counter_b
 
-        #     # merge the breakend support
-        #     split_ref = 0 # set these to zero unless there are informative alt bases for the ev type
+        # merge the breakend support
+        # split_ref = 0 # set these to zero unless there are informative alt bases for the ev type
         #     disc_ref = 0
         #     split_alt = sr_spl_a + sr_spl_b
         #     if split_alt > 0:
@@ -481,7 +528,7 @@ otype generated from the reference and alternate alleles given the sample ploidy
         #         split_ref = sr_ref_a + sr_ref_b
         #         disc_ref = conc_counter_a + conc_counter_b
 
-        #     split_scaled_ref = 0 # set these to zero unless there are informative alt bases for the ev type
+        # split_scaled_ref = 0 # set these to zero unless there are informative alt bases for the ev type
         #     disc_scaled_ref = 0
         #     split_scaled_alt = sr_spl_scaled_a + sr_spl_scaled_b
         #     if int(split_scaled_alt) > 0:
@@ -489,33 +536,33 @@ otype generated from the reference and alternate alleles given the sample ploidy
         #     disc_scaled_alt = disc_scaled_counter_a + disc_scaled_counter_b
         #     if int(disc_scaled_alt) > 0:
         #         disc_scaled_ref = conc_scaled_counter_a + conc_scaled_counter_b
-        #     if int(split_scaled_alt) == 0 and int(disc_scaled_alt) == 0: # if no alt alleles, set reference
+        # if int(split_scaled_alt) == 0 and int(disc_scaled_alt) == 0: # if no alt alleles, set reference
         #         split_scaled_ref = sr_ref_scaled_a + sr_ref_scaled_b
-        #         disc_scaled_ref = conc_scaled_counter_a + conc_scaled_counter_b
+        # disc_scaled_ref = conc_scaled_counter_a + conc_scaled_counter_b
 
         #     if split_scaled_alt + split_scaled_ref + disc_scaled_alt + disc_scaled_ref > 0:
-        #         # get bayesian classifier
+        # get bayesian classifier
         #         if var.info['SVTYPE'] == "DUP": is_dup = True
         #         else: is_dup = False
         #         gt_lplist = bayes_gt(int(split_weight * split_scaled_ref) + int(disc_weight * disc_scaled_ref), int(split_weight * split_scaled_alt) + int(disc_weight * disc_scaled_alt), is_dup)
         #         gt_idx = gt_lplist.index(max(gt_lplist))
 
-        #         # print log probabilities of homref, het, homalt
+        # print log probabilities of homref, het, homalt
         #         if debug:
         #             print gt_lplist
 
-        #         # set the overall variant QUAL score and sample specific fields
+        # set the overall variant QUAL score and sample specific fields
         #         var.genotype(sample.name).set_format('GL', ','.join(['%.0f' % x for x in gt_lplist]))
         #         var.genotype(sample.name).set_format('DP', int(split_scaled_ref + split_scaled_alt + disc_scaled_ref + disc_scaled_alt))
         #         var.genotype(sample.name).set_format('AO', int(split_scaled_alt + disc_scaled_alt))
         #         var.genotype(sample.name).set_format('RO', int(split_scaled_ref + disc_scaled_ref))
-        #         # if detailed:
+        # if detailed:
         #         var.genotype(sample.name).set_format('AS', int(split_scaled_alt))
         #         var.genotype(sample.name).set_format('RS', int(split_scaled_ref))
         #         var.genotype(sample.name).set_format('AP', int(disc_scaled_alt))
-        #         var.genotype(sample.name).set_format('RP', int(disc_scaled_ref))
+        # var.genotype(sample.name).set_format('RP', int(disc_scaled_ref))
 
-        #         # assign genotypes
+        # assign genotypes
         #         gt_sum = 0
         #         for gt in gt_lplist:
         #             try:
@@ -524,9 +571,9 @@ otype generated from the reference and alternate alleles given the sample ploidy
         #                 gt_sum += 0
         #         if gt_sum > 0:
         #             gt_sum_log = math.log(gt_sum, 10)
-        #             sample_qual = abs(-10 * (gt_lplist[0] - gt_sum_log)) # phred-scaled probability site is non-reference in this sample
+        # sample_qual = abs(-10 * (gt_lplist[0] - gt_sum_log)) # phred-scaled probability site is non-reference in this sample
         #             if 1 - (10**gt_lplist[gt_idx] / 10**gt_sum_log) == 0:
-        #                 phred_gq = 200                    
+        #                 phred_gq = 200
         #             else:
         #                 phred_gq = abs(-10 * math.log(1 - (10**gt_lplist[gt_idx] / 10**gt_sum_log), 10))
         #             var.genotype(sample.name).set_format('GQ', phred_gq)
@@ -550,7 +597,7 @@ otype generated from the reference and alternate alleles given the sample ploidy
             # var.genotype(sample.name).set_format('DP', 0)
             # var.genotype(sample.name).set_format('AO', 0)
             # var.genotype(sample.name).set_format('RO', 0)
-            # # if detailed:
+            # if detailed:
             # var.genotype(sample.name).set_format('AS', 0)
             # var.genotype(sample.name).set_format('RS', 0)
             # var.genotype(sample.name).set_format('AP', 0)
@@ -564,11 +611,12 @@ otype generated from the reference and alternate alleles given the sample ploidy
             var2.genotype = var.genotype
             vcf_out.write(var2.get_var_string() + '\n')
     vcf_out.close()
-    
+
     return
 
 # --------------------------------------
 # main function
+
 
 def main():
     # parse the command line args
@@ -584,6 +632,6 @@ def main():
 if __name__ == '__main__':
     try:
         sys.exit(main())
-    except IOError, e:
+    except IOError as e:
         if e.errno != 32:  # ignore SIGPIPE
-            raise 
+            raise

--- a/scripts/vcf_modify_header.py
+++ b/scripts/vcf_modify_header.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
 import pysam
-import argparse, sys
-import math, time, re
+import argparse
+import sys
+import math
+import time
+import re
 from collections import Counter
 from argparse import RawTextHelpFormatter
 
@@ -13,18 +16,25 @@ __date__ = "$Date: 2015-09-28 11:31 $"
 # --------------------------------------
 # define functions
 
+
 def get_args():
     parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter, description="\
 vcf_modify_header.py\n\
 author: " + __author__ + "\n\
 version: " + __version__ + "\n\
 description: Add or remove lines from the header")
-    parser.add_argument('-i', '--id', dest='vcf_id', metavar='STR', type=str, required=False, help='field id')
-    parser.add_argument('-c', '--category', dest='category', metavar='STR', type=str, help='INFO, FORMAT, FILTER')
-    parser.add_argument('-t', '--type', dest='type', metavar='STR', type=str, required=False, help='Number, String, Float, Integer')
-    parser.add_argument('-n', '--number', dest='number', metavar='STR', type=str, required=False, help='integer, A, R, G, or .')
-    parser.add_argument('-d', '--description', dest='description', metavar='STR', type=str, required=False, help='description')
-    parser.add_argument(metavar='vcf', dest='input_vcf', nargs='?', type=argparse.FileType('r'), default=None, help='VCF input (default: stdin)')
+    parser.add_argument('-i', '--id', dest='vcf_id',
+                        metavar='STR', type=str, required=False, help='field id')
+    parser.add_argument('-c', '--category', dest='category',
+                        metavar='STR', type=str, help='INFO, FORMAT, FILTER')
+    parser.add_argument('-t', '--type', dest='type', metavar='STR',
+                        type=str, required=False, help='Number, String, Float, Integer')
+    parser.add_argument('-n', '--number', dest='number', metavar='STR',
+                        type=str, required=False, help='integer, A, R, G, or .')
+    parser.add_argument('-d', '--description', dest='description',
+                        metavar='STR', type=str, required=False, help='description')
+    parser.add_argument(metavar='vcf', dest='input_vcf', nargs='?',
+                        type=argparse.FileType('r'), default=None, help='VCF input (default: stdin)')
 
     # parse the arguments
     args = parser.parse_args()
@@ -39,7 +49,9 @@ description: Add or remove lines from the header")
     # send back the user input
     return args
 
+
 class Vcf(object):
+
     def __init__(self):
         self.file_format = 'VCFv4.2'
         # self.fasta = fasta
@@ -58,19 +70,19 @@ class Vcf(object):
             elif line.split('=')[0] == '##reference':
                 self.reference = line.rstrip().split('=')[1]
             elif line.split('=')[0] == '##INFO':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_info(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##ALT':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_alt(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##FORMAT':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_format(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##FILTER':
-                a = line[line.find('<')+1:-2]
+                a = line[line.find('<') + 1:-2]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_filter(*[b.split('=')[1] for b in r.findall(a)])
             elif line[0] == '#' and line[1] != '#':
@@ -81,11 +93,11 @@ class Vcf(object):
         if include_samples:
             header = '\n'.join(['##fileformat=' + self.file_format,
                                 '##fileDate=' + time.strftime('%Y%m%d'),
-                                '##reference=' + self.reference] + \
-                               [f.hstring for f in self.filter_list] + \
-                               [i.hstring for i in self.info_list] + \
-                               [a.hstring for a in self.alt_list] + \
-                               [f.hstring for f in self.format_list] + \
+                                '##reference=' + self.reference] +
+                               [f.hstring for f in self.filter_list] +
+                               [i.hstring for i in self.info_list] +
+                               [a.hstring for a in self.alt_list] +
+                               [f.hstring for f in self.format_list] +
                                ['\t'.join([
                                    '#CHROM',
                                    'POS',
@@ -95,17 +107,17 @@ class Vcf(object):
                                    'QUAL',
                                    'FILTER',
                                    'INFO',
-                                   'FORMAT'] + \
-                                          self.sample_list
-                                      )])
+                                   'FORMAT'] +
+                                self.sample_list
+                                )])
         else:
             header = '\n'.join(['##fileformat=' + self.file_format,
                                 '##fileDate=' + time.strftime('%Y%m%d'),
-                                '##reference=' + self.reference] + \
-                               [f.hstring for f in self.filter_list] + \
-                               [i.hstring for i in self.info_list] + \
-                               [a.hstring for a in self.alt_list] + \
-                               [f.hstring for f in self.format_list] + \
+                                '##reference=' + self.reference] +
+                               [f.hstring for f in self.filter_list] +
+                               [i.hstring for i in self.info_list] +
+                               [a.hstring for a in self.alt_list] +
+                               [f.hstring for f in self.format_list] +
                                ['\t'.join([
                                    '#CHROM',
                                    'POS',
@@ -115,7 +127,7 @@ class Vcf(object):
                                    'QUAL',
                                    'FILTER',
                                    'INFO']
-                                          )])
+                               )])
         return header
 
     def add_info(self, id, number, type, desc):
@@ -153,6 +165,7 @@ class Vcf(object):
         return self.sample_list.index(sample) + 9
 
     class Info(object):
+
         def __init__(self, id, number, type, desc):
             self.id = str(id)
             self.number = str(number)
@@ -161,18 +174,22 @@ class Vcf(object):
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##INFO=<ID=' + self.id + ',Number=' + self.number + ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##INFO=<ID=' + self.id + ',Number=' + self.number + \
+                ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
 
     class Alt(object):
+
         def __init__(self, id, desc):
             self.id = str(id)
             self.desc = str(desc)
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##ALT=<ID=' + self.id + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##ALT=<ID=' + self.id + \
+                ',Description=\"' + self.desc + '\">'
 
     class Format(object):
+
         def __init__(self, id, number, type, desc):
             self.id = str(id)
             self.number = str(number)
@@ -181,18 +198,23 @@ class Vcf(object):
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##FORMAT=<ID=' + self.id + ',Number=' + self.number + ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##FORMAT=<ID=' + self.id + ',Number=' + self.number + \
+                ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
 
     class Filter(object):
+
         def __init__(self, id, desc):
             self.id = str(id)
             self.desc = str(desc)
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##FILTER=<ID=' + self.id + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##FILTER=<ID=' + self.id + \
+                ',Description=\"' + self.desc + '\">'
+
 
 class Variant(object):
+
     def __init__(self, var_list, vcf):
         self.chrom = var_list[0]
         self.pos = int(var_list[1])
@@ -210,10 +232,11 @@ class Variant(object):
         self.format_list = vcf.format_list
         self.active_formats = list()
         self.gts = dict()
-        
+
         # fill in empty sample genotypes
         if len(var_list) < 8:
-            sys.stderr.write('\nError: VCF file must have at least 8 columns\n')
+            sys.stderr.write(
+                '\nError: VCF file must have at least 8 columns\n')
             exit(1)
         if len(var_list) < 9:
             var_list.append("GT")
@@ -230,7 +253,8 @@ class Variant(object):
                 self.gts[s] = Genotype(self, s, './.')
 
         self.info = dict()
-        i_split = [a.split('=') for a in var_list[7].split(';')] # temp list of split info column
+        i_split = [a.split('=')
+                   for a in var_list[7].split(';')]  # temp list of split info column
         for i in i_split:
             if len(i) == 1:
                 i.append(True)
@@ -240,7 +264,8 @@ class Variant(object):
         if field in [i.id for i in self.info_list]:
             self.info[field] = value
         else:
-            sys.stderr.write('\nError: invalid INFO field, \"' + field + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid INFO field, \"' + field + '\"\n')
             exit(1)
 
     def get_info(self, field):
@@ -249,11 +274,12 @@ class Variant(object):
     def get_info_string(self):
         i_list = list()
         for info_field in self.info_list:
-            if info_field.id in self.info.keys():
+            if info_field.id in list(self.info.keys()):
                 if info_field.type == 'Flag':
                     i_list.append(info_field.id)
                 else:
-                    i_list.append('%s=%s' % (info_field.id, self.info[info_field.id]))
+                    i_list.append(
+                        '%s=%s' % (info_field.id, self.info[info_field.id]))
         return ';'.join(i_list)
 
     def get_format_string(self):
@@ -267,10 +293,11 @@ class Variant(object):
         if sample_name in self.sample_list:
             return self.gts[sample_name]
         else:
-            sys.stderr.write('\nError: invalid sample name, \"' + sample_name + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid sample name, \"' + sample_name + '\"\n')
 
     def get_var_string(self):
-        s = '\t'.join(map(str,[
+        s = '\t'.join(map(str, [
             self.chrom,
             self.pos,
             self.var_id,
@@ -280,11 +307,14 @@ class Variant(object):
             self.filter,
             self.get_info_string(),
             self.get_format_string(),
-            '\t'.join(self.genotype(s).get_gt_string() for s in self.sample_list)
+            '\t'.join(self.genotype(s).get_gt_string()
+                      for s in self.sample_list)
         ]))
         return s
 
+
 class Genotype(object):
+
     def __init__(self, variant, sample_name, gt):
         self.format = dict()
         self.variant = variant
@@ -296,9 +326,11 @@ class Genotype(object):
             if field not in self.variant.active_formats:
                 self.variant.active_formats.append(field)
                 # sort it to be in the same order as the format_list in header
-                self.variant.active_formats.sort(key=lambda x: [f.id for f in self.variant.format_list].index(x))
+                self.variant.active_formats.sort(
+                    key=lambda x: [f.id for f in self.variant.format_list].index(x))
         else:
-            sys.stderr.write('\nError: invalid FORMAT field, \"' + field + '\"\n')
+            sys.stderr.write(
+                '\nError: invalid FORMAT field, \"' + field + '\"\n')
             exit(1)
 
     def get_format(self, field):
@@ -314,9 +346,11 @@ class Genotype(object):
                     g_list.append(self.format[f])
             else:
                 g_list.append('.')
-        return ':'.join(map(str,g_list))
+        return ':'.join(map(str, g_list))
 
 # primary function
+
+
 def mod_header(vcf_id,
                category,
                f_type,
@@ -325,7 +359,8 @@ def mod_header(vcf_id,
                vcf_file):
     in_header = True
     header = []
-    breakend_dict = {} # cache to hold unmatched generic breakends for genotyping
+    breakend_dict = {}
+        # cache to hold unmatched generic breakends for genotyping
     vcf = Vcf()
     vcf_out = sys.stdout
 
@@ -333,7 +368,7 @@ def mod_header(vcf_id,
     for line in vcf_file:
         if in_header:
             if line[0] == '#':
-                header.append(line) 
+                header.append(line)
                 if line[1] != '#':
                     vcf_samples = line.rstrip().split('\t')[9:]
                 continue
@@ -355,11 +390,12 @@ def mod_header(vcf_id,
                     vcf_out.write(vcf.get_header(include_samples=False) + '\n')
         vcf_out.write(line)
     vcf_out.close()
-    
+
     return
 
 # --------------------------------------
 # main function
+
 
 def main():
     # parse the command line args
@@ -380,6 +416,6 @@ def main():
 if __name__ == '__main__':
     try:
         sys.exit(main())
-    except IOError, e:
+    except IOError as e:
         if e.errno != 32:  # ignore SIGPIPE
-            raise 
+            raise

--- a/scripts/vcf_paste.py
+++ b/scripts/vcf_paste.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-import argparse, sys
+import argparse
+import sys
 from argparse import RawTextHelpFormatter
 import gzip
 
@@ -11,6 +12,7 @@ __date__ = "$Date: 2015-04-13 14:31 $"
 # --------------------------------------
 # define functions
 
+
 def get_args():
     parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter, description="\
 vcf_paste.py\n\
@@ -19,13 +21,21 @@ version: " + __version__ + "\n\
 description: Paste VCFs from multiple samples")
     # parser.add_argument('-a', '--argA', metavar='argA', type=str, required=True, help='description of argument')
     # parser.add_argument('-b', '--argB', metavar='argB', required=False, help='description of argument B')
-    # parser.add_argument('-c', '--flagC', required=False, action='store_true', help='sets flagC to true')
-    parser.add_argument('-m', '--master', type=argparse.FileType('r'), default=None, help='VCF file to set first 8 columns of variant info [first file in vcf_list]')
-    parser.add_argument('-q', '--sum_quals', required=False, action='store_true', help='Sum QUAL scores of input VCFs as output QUAL score')
-    # parser.add_argument('-s', '--safe', action='store_true', help='Check to ensure the variant positions match the master. Safe, but slower.')
-    parser.add_argument('-f', '--vcf_list', required=True, help='Line-delimited list of VCF files to paste')
+    # parser.add_argument('-c', '--flagC', required=False,
+    # action='store_true', help='sets flagC to true')
+    parser.add_argument(
+        '-m', '--master', type=argparse.FileType('r'), default=None,
+                        help='VCF file to set first 8 columns of variant info [first file in vcf_list]')
+    parser.add_argument(
+        '-q', '--sum_quals', required=False, action='store_true',
+                        help='Sum QUAL scores of input VCFs as output QUAL score')
+    # parser.add_argument('-s', '--safe', action='store_true', help='Check to
+    # ensure the variant positions match the master. Safe, but slower.')
+    parser.add_argument('-f', '--vcf_list', required=True,
+                        help='Line-delimited list of VCF files to paste')
 
-    # parser.add_argument('vcf_list', metavar='vcf', nargs='*', type=argparse.FileType('r'), default=None, help='VCF file(s) to join')
+    # parser.add_argument('vcf_list', metavar='vcf', nargs='*',
+    # type=argparse.FileType('r'), default=None, help='VCF file(s) to join')
 
     # parse the arguments
     args = parser.parse_args()
@@ -38,8 +48,10 @@ description: Paste VCFs from multiple samples")
     return args
 
 # primary function
+
+
 def svt_join(master, sum_quals, vcf_list):
-    max_split=9
+    max_split = 9
 
     # if master not provided, set as first VCF
     if master is None:
@@ -59,7 +71,7 @@ def svt_join(master, sum_quals, vcf_list):
             break
         if master_line[:2] != "##":
             break
-        print (master_line.rstrip())
+        print(master_line.rstrip())
 
     # get sample names
     out_v = master_line.rstrip().split('\t', max_split)[:9]
@@ -74,17 +86,17 @@ def svt_join(master, sum_quals, vcf_list):
                 line_v = line.rstrip().split('\t', max_split)
                 out_v = out_v + line_v[9:]
                 break
-    sys.stdout.write( '\t'.join(map(str, out_v)) + '\n')
-    
+    sys.stdout.write('\t'.join(map(str, out_v)) + '\n')
+
     # iterate through VCF body
     while 1:
         master_line = master.readline()
         if not master_line:
             break
         master_v = master_line.rstrip().split('\t', max_split)
-        out_v = master_v[:8] # output array of fields
+        out_v = master_v[:8]  # output array of fields
         qual = float(out_v[5])
-        format = None # column 9, VCF format field.
+        format = None  # column 9, VCF format field.
 
         for vcf in vcf_list:
             line = vcf.readline()
@@ -104,17 +116,18 @@ def svt_join(master, sum_quals, vcf_list):
             out_v = out_v + line_v[9:]
         if sum_quals:
             out_v[5] = qual
-        sys.stdout.write( '\t'.join(map(str, out_v)) + '\n')
-    
+        sys.stdout.write('\t'.join(map(str, out_v)) + '\n')
+
     # close files
     master.close()
     for vcf in vcf_list:
         vcf.close()
-    
+
     return
 
 # --------------------------------------
 # main function
+
 
 def main():
     # parse the command line args
@@ -128,16 +141,18 @@ def main():
             vcf_list.append(gzip.open(path, 'rb'))
         else:
             vcf_list.append(open(path, 'r'))
-    
-    # vcf_list = [open(line.rstrip('\n'), 'r') for line in open(args.vcf_list, 'r')]
+
+    # vcf_list = [open(line.rstrip('\n'), 'r') for line in open(args.vcf_list,
+    # 'r')]
 
     # call primary function
     svt_join(args.master, args.sum_quals, vcf_list)
+
 
 # initialize the script
 if __name__ == '__main__':
     try:
         sys.exit(main())
-    except IOError, e:
+    except IOError as e:
         if e.errno != 32:  # ignore SIGPIPE
             raise

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     install_requires=[
-        'pysam>=0.12.0',
+        'pysam>=0.11.2.2',
         'numpy',
         'scipy',
         'cytoolz>=0.8.2',

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         [console_scripts]
         svtyper=svtyper.classic:cli
         svtyper-sso=svtyper.singlesample:cli
+        svtyper-pms=svtyper.parallelsample:cli
     ''',
     packages=find_packages(exclude=('tests', 'etc')),
     include_package_data=True,

--- a/svtyper/classic.py
+++ b/svtyper/classic.py
@@ -470,10 +470,15 @@ def sv_genotype(bam_string,
                 alt_span = 0
                 ref_span = 0
 
+            if alt_span + alt_seq == 0 and alt_clip > 0:
+                # discount any SV that's only supported by clips.
+                alt_clip = 0
+
             if ref_seq + alt_seq + ref_span + alt_span + alt_clip > 0:
                 # get bayesian classifier
                 if var.info['SVTYPE'] == "DUP": is_dup = True
                 else: is_dup = False
+
                 alt_splitters = alt_seq + alt_clip
                 QR = int(split_weight * ref_seq) + int(disc_weight * ref_span)
                 QA = int(split_weight * alt_splitters) + int(disc_weight * alt_span)
@@ -553,6 +558,10 @@ def sv_genotype(bam_string,
             var2.active_formats = var.active_formats
             var2.genotype = var.genotype
             vcf_out.write(var2.get_var_string() + '\n')
+
+    # throw warning if we've lost unpaired breakends
+    if breakend_dict:
+        logging.warning('Unpaired breakends found in file. These will not be present in output.')
 
     # close the files
     vcf_in.close()

--- a/svtyper/parallelsample.py
+++ b/svtyper/parallelsample.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse
+from argparse import RawTextHelpFormatter
+import os
+import multiprocessing
+from functools import partial
+from subprocess import call
+
+
+from pysam import AlignmentFile, tabix_compress, tabix_index
+from svtyper import singlesample as single
+from svtyper import version as svtyper_version
+
+def get_args():
+    parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter, description="\
+        svtyper\n\
+        author: " + svtyper_version.__author__ + "\n\
+        version: " + svtyper_version.__version__ + "\n\
+        description: Compute genotype of structural variants based on breakpoint depth")
+
+    parser.add_argument('-B', '--bam',
+                        type=str, required=True,
+                        help='BAM list files')
+    parser.add_argument('-i', '--input_vcf',
+                        type=str, required=True,
+                        help='VCF input')
+    parser.add_argument('-o', '--output_vcf',
+                        type=str, required=True,
+                        help='output VCF to write')
+    parser.add_argument('-t', '--threads', type=int, default=1,
+                        help='number of threads to use (set at maximum number of available cores)')
+
+    return parser.parse_args()
+    
+
+def fetchId(bamfile):
+    """
+    Fetch sample id in a bam file
+    :param bamfile: the bam file
+    :type bamfile: file
+    :return: sample name
+    :rtype: str
+    """
+    bamfile_fin = AlignmentFile(bamfile, 'rb')
+    name = bamfile_fin.header['RG'][0]['SM']
+    bamfile_fin.close()
+    return name
+
+
+def get_bamfiles(bamlist):
+    with open(bamlist, "r") as fin:
+        bamfiles = [os.path.abspath(f.strip()) for f in fin]
+    return bamfiles
+
+
+def genotype_multiple_samples(bamlist, vcf_in, vcf_out, cores=1):
+
+    bamfiles = get_bamfiles(bamlist)
+
+    pool = multiprocessing.Pool(processes=cores)
+    launch_ind = partial(genotype_single_sample,
+                         vcf_in=vcf_in, out_dir=os.path.dirname(vcf_out))
+
+    vcf_files = pool.map(launch_ind, bamfiles)
+
+    merge_cmd = "bcftools merge -m id -O z " + " -o " + vcf_out + " " + " ".join(vcf_files)
+
+    call(merge_cmd, shell=True)
+    tabix_index(vcf_out, force=True, preset="vcf")
+
+    for vcf_file in vcf_files:
+        os.remove(vcf_file)
+        if os.path.exists(vcf_file[:-3]):
+            os.remove(vcf_file[:-3])
+        tbi = vcf_file + ".tbi"
+        if os.path.exists(tbi):
+            os.remove(tbi)
+        
+
+def genotype_single_sample(bam, vcf_in, out_dir):
+    lib_info_json = bam + ".json"
+    sample = fetchId(bam)
+    out_vcf = os.path.join(out_dir, sample + ".gt.vcf")
+    with open(vcf_in, "r") as inf, open(out_vcf, "w") as outf:
+        single.sso_genotype(bam_string=bam,
+                       vcf_in=inf,
+                       vcf_out=outf,
+                       min_aligned=20,
+                       split_weight=1,
+                       disc_weight=1,
+                       num_samp=1000000,
+                       lib_info_path=lib_info_json,
+                       debug=False,
+                       ref_fasta=None,
+                       sum_quals=False,
+                       max_reads=1000,
+                       cores=None,
+                       batch_size=None)
+    out_gz = out_vcf + ".gz"
+    tabix_compress(out_vcf, out_gz, force=True)
+    tabix_index(out_gz, force=True, preset="vcf")
+    return out_gz
+
+
+def main():
+    args = get_args()
+    
+    genotype_multiple_samples(args.bam, args.input_vcf, args.output_vcf, cores=args.threads)
+
+
+def cli():
+    try:
+        sys.exit(main())
+    except IOError as e:
+        if e.errno != 32:  # ignore SIGPIPE
+            raise
+
+
+if __name__ == '__main__':
+    cli()

--- a/svtyper/parallelsample.py
+++ b/svtyper/parallelsample.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
 import sys
+import gzip
 import argparse
+import shutil
+import tempfile
 from argparse import RawTextHelpFormatter
 import os
 import multiprocessing
@@ -12,6 +15,7 @@ from subprocess import call
 from pysam import AlignmentFile, tabix_compress, tabix_index
 from svtyper import singlesample as single
 from svtyper import version as svtyper_version
+
 
 def get_args():
     parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter, description="\
@@ -24,16 +28,22 @@ def get_args():
                         type=str, required=True,
                         help='BAM list files')
     parser.add_argument('-i', '--input_vcf',
-                        type=str, required=True,
+                        type=str, required=False, default=None,
                         help='VCF input')
     parser.add_argument('-o', '--output_vcf',
-                        type=str, required=True,
+                        type=str, required=False, default=None,
                         help='output VCF to write')
     parser.add_argument('-t', '--threads', type=int, default=1,
                         help='number of threads to use (set at maximum number of available cores)')
 
-    return parser.parse_args()
-    
+    args = parser.parse_args()
+
+    if args.input_vcf is None:
+        args.input_vcf = sys.stdin
+    if args.output_vcf is None:
+        args.output_vcf = sys.stdout
+
+    return args
 
 def fetchId(bamfile):
     """
@@ -59,24 +69,59 @@ def genotype_multiple_samples(bamlist, vcf_in, vcf_out, cores=1):
 
     bamfiles = get_bamfiles(bamlist)
 
+    tmp_files = []
+
+    if vcf_out == sys.stdout:
+        out_dir = tempfile.mkdtemp()
+        tmp_files.append(out_dir)
+    else:
+        out_dir = os.path.dirname(vcf_out)
+
+    if vcf_in == sys.stdin:
+        vcf_in = single.dump_piped_vcf_to_file(vcf_in, out_dir)
+        tmp_files.append(vcf_in)
+    elif vcf_in.endswith(".gz"):
+        vcf_in_gz = vcf_in
+        vcf_in = vcf_in[:-3]
+        with gzip.open(vcf_in_gz, 'rb') as f_in:
+            with open(vcf_in, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        tmp_files.append(vcf_in)
+
     pool = multiprocessing.Pool(processes=cores)
     launch_ind = partial(genotype_single_sample,
-                         vcf_in=vcf_in, out_dir=os.path.dirname(vcf_out))
+                         vcf_in=vcf_in, out_dir=out_dir)
 
     vcf_files = pool.map(launch_ind, bamfiles)
+    tmp_files += vcf_files
 
-    merge_cmd = "bcftools merge -m id -O z " + " -o " + vcf_out + " " + " ".join(vcf_files)
+    merge_cmd = "bcftools merge -m id "
 
-    call(merge_cmd, shell=True)
-    tabix_index(vcf_out, force=True, preset="vcf")
+    if vcf_out != sys.stdout:
+        merge_cmd += "-O z " + " -o " + vcf_out + " "
 
-    for vcf_file in vcf_files:
-        os.remove(vcf_file)
-        if os.path.exists(vcf_file[:-3]):
-            os.remove(vcf_file[:-3])
-        tbi = vcf_file + ".tbi"
-        if os.path.exists(tbi):
-            os.remove(tbi)
+    merge_cmd += " ".join(vcf_files)
+
+    exit_code = call(merge_cmd, shell=True)
+
+    if exit_code == 0:
+        if vcf_out != sys.stdout:
+            tabix_index(vcf_out, force=True, preset="vcf")
+
+        for tmp_file in tmp_files:
+            if os.path.isdir(tmp_file):
+                shutil.rmtree(tmp_file)
+            elif os.path.exists(tmp_file):
+                os.remove(tmp_file)
+                if tmp_file.endswith(".gz"):
+                    if os.path.exists(tmp_file[:-3]):
+                        os.remove(tmp_file[:-3])
+                    tbi = tmp_file + ".tbi"
+                    if os.path.exists(tbi):
+                        os.remove(tbi)
+    else:
+        print("Failed: bcftools merge exits with status %d" % exit_code)
+        exit(1)
         
 
 def genotype_single_sample(bam, vcf_in, out_dir):
@@ -85,19 +130,19 @@ def genotype_single_sample(bam, vcf_in, out_dir):
     out_vcf = os.path.join(out_dir, sample + ".gt.vcf")
     with open(vcf_in, "r") as inf, open(out_vcf, "w") as outf:
         single.sso_genotype(bam_string=bam,
-                       vcf_in=inf,
-                       vcf_out=outf,
-                       min_aligned=20,
-                       split_weight=1,
-                       disc_weight=1,
-                       num_samp=1000000,
-                       lib_info_path=lib_info_json,
-                       debug=False,
-                       ref_fasta=None,
-                       sum_quals=False,
-                       max_reads=1000,
-                       cores=None,
-                       batch_size=None)
+                            vcf_in=inf,
+                            vcf_out=outf,
+                            min_aligned=20,
+                            split_weight=1,
+                            disc_weight=1,
+                            num_samp=1000000,
+                            lib_info_path=lib_info_json,
+                            debug=False,
+                            ref_fasta=None,
+                            sum_quals=False,
+                            max_reads=1000,
+                            cores=None,
+                            batch_size=None)
     out_gz = out_vcf + ".gz"
     tabix_compress(out_vcf, out_gz, force=True)
     tabix_index(out_gz, force=True, preset="vcf")

--- a/svtyper/parsers.py
+++ b/svtyper/parsers.py
@@ -1,6 +1,9 @@
-from __future__ import print_function
 
-import time, re, json, sys
+
+import time
+import re
+import json
+import sys
 from collections import Counter
 
 from svtyper.statistics import mean, stdev, median, upper_mad
@@ -9,7 +12,9 @@ from svtyper.statistics import mean, stdev, median, upper_mad
 # VCF parsing tools
 # ==================================================
 
+
 class Vcf(object):
+
     def __init__(self):
         self.file_format = 'VCFv4.2'
         # self.fasta = fasta
@@ -26,19 +31,31 @@ class Vcf(object):
     def add_custom_svtyper_headers(self):
         self.add_info('SVTYPE', 1, 'String', 'Type of structural variant')
         self.add_format('GQ', 1, 'Integer', 'Genotype quality')
-        self.add_format('SQ', 1, 'Float', 'Phred-scaled probability that this site is variant (non-reference in this sample')
-        self.add_format('GL', 'G', 'Float', 'Genotype Likelihood, log10-scaled likelihoods of the data given the called genotype for each possible genotype generated from the reference and alternate alleles given the sample ploidy')
+        self.add_format(
+            'SQ', 1, 'Float', 'Phred-scaled probability that this site is variant (non-reference in this sample')
+        self.add_format(
+            'GL', 'G', 'Float', 'Genotype Likelihood, log10-scaled likelihoods of the data given the called genotype for each possible genotype generated from the reference and alternate alleles given the sample ploidy')
         self.add_format('DP', 1, 'Integer', 'Read depth')
-        self.add_format('RO', 1, 'Integer', 'Reference allele observation count, with partial observations recorded fractionally')
-        self.add_format('AO', 'A', 'Integer', 'Alternate allele observations, with partial observations recorded fractionally')
-        self.add_format('QR', 1, 'Integer', 'Sum of quality of reference observations')
-        self.add_format('QA', 'A', 'Integer', 'Sum of quality of alternate observations')
-        self.add_format('RS', 1, 'Integer', 'Reference allele split-read observation count, with partial observations recorded fractionally')
-        self.add_format('AS', 'A', 'Integer', 'Alternate allele split-read observation count, with partial observations recorded fractionally')
-        self.add_format('ASC', 'A', 'Integer', 'Alternate allele clipped-read observation count, with partial observations recorded fractionally')
-        self.add_format('RP', 1, 'Integer', 'Reference allele paired-end observation count, with partial observations recorded fractionally')
-        self.add_format('AP', 'A', 'Integer', 'Alternate allele paired-end observation count, with partial observations recorded fractionally')
-        self.add_format('AB', 'A', 'Float', 'Allele balance, fraction of observations from alternate allele, QA/(QR+QA)')
+        self.add_format(
+            'RO', 1, 'Integer', 'Reference allele observation count, with partial observations recorded fractionally')
+        self.add_format(
+            'AO', 'A', 'Integer', 'Alternate allele observations, with partial observations recorded fractionally')
+        self.add_format(
+            'QR', 1, 'Integer', 'Sum of quality of reference observations')
+        self.add_format(
+            'QA', 'A', 'Integer', 'Sum of quality of alternate observations')
+        self.add_format(
+            'RS', 1, 'Integer', 'Reference allele split-read observation count, with partial observations recorded fractionally')
+        self.add_format(
+            'AS', 'A', 'Integer', 'Alternate allele split-read observation count, with partial observations recorded fractionally')
+        self.add_format(
+            'ASC', 'A', 'Integer', 'Alternate allele clipped-read observation count, with partial observations recorded fractionally')
+        self.add_format(
+            'RP', 1, 'Integer', 'Reference allele paired-end observation count, with partial observations recorded fractionally')
+        self.add_format(
+            'AP', 'A', 'Integer', 'Alternate allele paired-end observation count, with partial observations recorded fractionally')
+        self.add_format(
+            'AB', 'A', 'Float', 'Allele balance, fraction of observations from alternate allele, QA/(QR+QA)')
 
     def add_header(self, header):
         for line in header:
@@ -47,15 +64,15 @@ class Vcf(object):
             elif line.split('=')[0] == '##reference':
                 self.reference = line.rstrip().split('=')[1]
             elif line.split('=')[0] == '##INFO':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_info(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##ALT':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_alt(*[b.split('=')[1] for b in r.findall(a)])
             elif line.split('=')[0] == '##FORMAT':
-                a = line[line.find('<')+1:line.find('>')]
+                a = line[line.find('<') + 1:line.find('>')]
                 r = re.compile(r'(?:[^,\"]|\"[^\"]*\")+')
                 self.add_format(*[b.split('=')[1] for b in r.findall(a)])
             elif line[0] == '#' and line[1] != '#':
@@ -69,11 +86,11 @@ class Vcf(object):
     def get_header(self):
         header = '\n'.join(['##fileformat=' + self.file_format,
                             '##fileDate=' + time.strftime('%Y%m%d'),
-                            '##reference=' + self.reference] + \
-                           [i.hstring for i in self.info_list] + \
-                           [a.hstring for a in self.alt_list] + \
-                           [f.hstring for f in self.format_list] + \
-                           self.header_misc + \
+                            '##reference=' + self.reference] +
+                           [i.hstring for i in self.info_list] +
+                           [a.hstring for a in self.alt_list] +
+                           [f.hstring for f in self.format_list] +
+                           self.header_misc +
                            ['\t'.join([
                                '#CHROM',
                                'POS',
@@ -83,9 +100,9 @@ class Vcf(object):
                                'QUAL',
                                'FILTER',
                                'INFO',
-                               'FORMAT'] + \
-                                      self.sample_list
-                                  )])
+                               'FORMAT'] +
+                            self.sample_list
+                            )])
         return header
 
     def write_header(self, fd=None):
@@ -129,22 +146,24 @@ class Vcf(object):
                 posA = var.pos
                 posB = var2.pos
                 # confidence intervals
-                ciA = map(int, var.info['CIPOS'].split(','))
-                ciB = map(int, var2.info['CIPOS'].split(','))
+                ciA = list(map(int, var.info['CIPOS'].split(',')))
+                ciB = list(map(int, var2.info['CIPOS'].split(',')))
 
                 # infer the strands from the alt allele
                 if var.alt[-1] == '[' or var.alt[-1] == ']':
                     o1_is_reverse = False
-                else: o1_is_reverse = True
+                else:
+                    o1_is_reverse = True
                 if var2.alt[-1] == '[' or var2.alt[-1] == ']':
                     o2_is_reverse = False
-                else: o2_is_reverse = True
+                else:
+                    o2_is_reverse = True
 
                 breakpoints = {
-                    'id' : var.var_id,
-                    'svtype' : 'BND',
-                    'A' : {'chrom': chromA, 'pos' : posA, 'ci': ciA, 'is_reverse': o1_is_reverse},
-                    'B' : {'chrom': chromB, 'pos' : posB, 'ci': ciB, 'is_reverse': o2_is_reverse},
+                    'id': var.var_id,
+                    'svtype': 'BND',
+                    'A': {'chrom': chromA, 'pos': posA, 'ci': ciA, 'is_reverse': o1_is_reverse},
+                    'B': {'chrom': chromB, 'pos': posB, 'ci': ciB, 'is_reverse': o2_is_reverse},
                 }
 
                 for k in ('A', 'B'):
@@ -159,7 +178,7 @@ class Vcf(object):
             else:
                 bnd_cache[variant.var_id] = variant
                 return None
-         
+
         return _get_bnd_breakpoints
 
     @staticmethod
@@ -169,31 +188,31 @@ class Vcf(object):
         posA = variant.pos
         posB = int(variant.get_info('END'))
         # confidence intervals
-        ciA = map(int, variant.info['CIPOS'].split(','))
-        ciB = map(int, variant.info['CIEND'].split(','))
+        ciA = list(map(int, variant.info['CIPOS'].split(',')))
+        ciB = list(map(int, variant.info['CIEND'].split(',')))
         svtype = variant.get_svtype()
         if svtype == 'DEL':
             var_length = posB - posA
-            o1_is_reverse, o2_is_reverse =  False, True
+            o1_is_reverse, o2_is_reverse = False, True
         elif svtype == 'DUP':
-            o1_is_reverse, o2_is_reverse =  True, False
+            o1_is_reverse, o2_is_reverse = True, False
         elif svtype == 'INV':
             o1_is_reverse, o2_is_reverse = False, False
 
         if svtype != 'DEL':
             breakpoints = {
-                'id' : variant.var_id,
-                'svtype' : svtype,
-                'A' : {'chrom': chromA, 'pos' : posA, 'ci': ciA, 'is_reverse': o1_is_reverse},
-                'B' : {'chrom': chromB, 'pos' : posB, 'ci': ciB, 'is_reverse': o2_is_reverse},
+                'id': variant.var_id,
+                'svtype': svtype,
+                'A': {'chrom': chromA, 'pos': posA, 'ci': ciA, 'is_reverse': o1_is_reverse},
+                'B': {'chrom': chromB, 'pos': posB, 'ci': ciB, 'is_reverse': o2_is_reverse},
             }
         else:
             breakpoints = {
-                'id' : variant.var_id,
-                'svtype' : svtype,
-                'var_length' : var_length,
-                'A' : {'chrom': chromA, 'pos' : posA, 'ci': ciA, 'is_reverse': o1_is_reverse},
-                'B' : {'chrom': chromB, 'pos' : posB, 'ci': ciB, 'is_reverse': o2_is_reverse},
+                'id': variant.var_id,
+                'svtype': svtype,
+                'var_length': var_length,
+                'A': {'chrom': chromA, 'pos': posA, 'ci': ciA, 'is_reverse': o1_is_reverse},
+                'B': {'chrom': chromB, 'pos': posB, 'ci': ciB, 'is_reverse': o2_is_reverse},
             }
 
         for k in ('A', 'B'):
@@ -217,6 +236,7 @@ class Vcf(object):
         return breakpoints
 
     class Info(object):
+
         def __init__(self, id, number, type, desc):
             self.id = str(id)
             self.number = str(number)
@@ -225,18 +245,22 @@ class Vcf(object):
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##INFO=<ID=' + self.id + ',Number=' + self.number + ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##INFO=<ID=' + self.id + ',Number=' + self.number + \
+                ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
 
     class Alt(object):
+
         def __init__(self, id, desc):
             self.id = str(id)
             self.desc = str(desc)
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##ALT=<ID=' + self.id + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##ALT=<ID=' + self.id + \
+                ',Description=\"' + self.desc + '\">'
 
     class Format(object):
+
         def __init__(self, id, number, type, desc):
             self.id = str(id)
             self.number = str(number)
@@ -245,9 +269,12 @@ class Vcf(object):
             # strip the double quotes around the string if present
             if self.desc.startswith('"') and self.desc.endswith('"'):
                 self.desc = self.desc[1:-1]
-            self.hstring = '##FORMAT=<ID=' + self.id + ',Number=' + self.number + ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+            self.hstring = '##FORMAT=<ID=' + self.id + ',Number=' + self.number + \
+                ',Type=' + self.type + ',Description=\"' + self.desc + '\">'
+
 
 class Variant(object):
+
     def __init__(self, var_list, vcf):
         self.chrom = var_list[0]
         self.pos = int(var_list[1])
@@ -279,13 +306,15 @@ class Variant(object):
                 s_gt = var_list[vcf.sample_to_col(s)].split(':')[0]
                 self.gts[s] = Genotype(self, s, s_gt)
                 # import the existing fmt fields
-                for j in zip(var_list[8].split(':'), var_list[vcf.sample_to_col(s)].split(':')):
+                for j in zip(var_list[8].split(':'),
+                             var_list[vcf.sample_to_col(s)].split(':')):
                     self.gts[s].set_format(j[0], j[1])
             except IndexError:
                 self.gts[s] = Genotype(self, s, './.')
 
         self.info = dict()
-        i_split = [a.split('=') for a in var_list[7].split(';')] # temp list of split info column
+        i_split = [a.split('=')
+                   for a in var_list[7].split(';')]  # temp list of split info column
         for i in i_split:
             if len(i) == 1:
                 i.append(True)
@@ -304,11 +333,12 @@ class Variant(object):
     def get_info_string(self):
         i_list = list()
         for info_field in self.info_list:
-            if info_field.id in self.info.keys():
+            if info_field.id in list(self.info.keys()):
                 if info_field.type == 'Flag':
                     i_list.append(info_field.id)
                 else:
-                    i_list.append('%s=%s' % (info_field.id, self.info[info_field.id]))
+                    i_list.append('%s=%s' % (info_field.id,
+                                             self.info[info_field.id]))
         return ';'.join(i_list)
 
     def get_format_string(self):
@@ -322,10 +352,11 @@ class Variant(object):
         if sample_name in self.sample_list:
             return self.gts[sample_name]
         else:
-            sys.stderr.write('Error: invalid sample name, \"' + sample_name + '\"\n')
+            sys.stderr.write(
+                'Error: invalid sample name, \"' + sample_name + '\"\n')
 
     def get_var_string(self):
-        s = '\t'.join(map(str,[
+        s = '\t'.join(map(str, [
             self.chrom,
             self.pos,
             self.var_id,
@@ -335,7 +366,8 @@ class Variant(object):
             self.filter,
             self.get_info_string(),
             self.get_format_string(),
-            '\t'.join(self.genotype(s).get_gt_string() for s in self.sample_list)
+            '\t'.join(self.genotype(s).get_gt_string()
+                      for s in self.sample_list)
         ]))
         return s
 
@@ -360,7 +392,9 @@ class Variant(object):
         flag = svtype in ('BND', 'DEL', 'DUP', 'INV')
         return flag
 
+
 class Genotype(object):
+
     def __init__(self, variant, sample_name, gt):
         self.format = dict()
         self.variant = variant
@@ -372,9 +406,11 @@ class Genotype(object):
             if field not in self.variant.active_formats:
                 self.variant.active_formats.append(field)
                 # sort it to be in the same order as the format_list in header
-                self.variant.active_formats.sort(key=lambda x: [f.id for f in self.variant.format_list].index(x))
+                self.variant.active_formats.sort(
+                    key=lambda x: [f.id for f in self.variant.format_list].index(x))
         else:
-            sys.stderr.write('Error: invalid FORMAT field, \"' + field + '\"\n')
+            sys.stderr.write(
+                'Error: invalid FORMAT field, \"' + field + '\"\n')
             exit(1)
 
     def get_format(self, field):
@@ -390,14 +426,16 @@ class Genotype(object):
                     g_list.append(self.format[f])
             else:
                 g_list.append('.')
-        return ':'.join(map(str,g_list))
+        return ':'.join(map(str, g_list))
 
 # ==================================================
 # Library parsing
 # ==================================================
 
+
 # holds a library's insert size and read length information
 class Library(object):
+
     def __init__(self,
                  name,
                  bam,
@@ -432,7 +470,8 @@ class Library(object):
         if self.prevalence is None:
             self.calc_lib_prevalence()
 
-        # remove the uneeded attribute (only needed during object initialization)
+        # remove the uneeded attribute (only needed during object
+        # initialization)
         del self.bam
 
     def cleanup(self):
@@ -450,7 +489,7 @@ class Library(object):
         lib = lib_info[sample_name]['libraryArray'][lib_index]
 
         # convert the histogram keys to integers (from strings in JSON)
-        lib_hist = {int(k):int(v) for k,v in lib['histogram'].items()}
+        lib_hist = {int(k): int(v) for k, v in list(lib['histogram'].items())}
 
         return cls(lib['library_name'],
                    bam,
@@ -474,7 +513,7 @@ class Library(object):
         for r in bam.header['RG']:
             try:
                 in_lib = r['LB'] == lib_name
-            except KeyError, e:
+            except KeyError as e:
                 in_lib = lib_name == ''
 
             if in_lib:
@@ -514,6 +553,8 @@ class Library(object):
         for read in self.bam.fetch():
             if read.get_tag('RG') not in self.readgroups:
                 continue
+            if read.cigarstring is None:
+                continue
             if read.infer_query_length() > max_rl:
                 max_rl = read.infer_query_length()
             if counter == num_samp:
@@ -541,12 +582,12 @@ class Library(object):
                 skip_counter += 1
                 continue
             if (read.is_reverse
-                or not read.mate_is_reverse
-                or read.is_unmapped
-                or read.mate_is_unmapped
-                or not self.is_primary(read)
-                or read.template_length <= 0
-                or read.get_tag('RG') not in self.readgroups):
+                    or not read.mate_is_reverse
+                    or read.is_unmapped
+                    or read.mate_is_unmapped
+                    or not self.is_primary(read)
+                    or read.template_length <= 0
+                    or read.get_tag('RG') not in self.readgroups):
                 continue
             else:
                 valueCounts[read.template_length] += 1
@@ -573,7 +614,7 @@ Please ensure BAM file (%s) has inward facing, paired-end reads.\n' % self.bam.f
     def calc_insert_density(self):
         dens = Counter()
         for i in list(self.hist):
-            dens[i] = float(self.hist[i])/self.countRecords(self.hist)
+            dens[i] = float(self.hist[i]) / self.countRecords(self.hist)
         self.dens = dens
 
     def countRecords(self, myCounter):
@@ -584,9 +625,11 @@ Please ensure BAM file (%s) has inward facing, paired-end reads.\n' % self.bam.f
 # Sample parsing
 # ==================================================
 
+
 # holds each sample's BAM and library information
 class Sample(object):
     # general constructor
+
     def __init__(self,
                  name,
                  bam,
@@ -606,7 +649,7 @@ class Sample(object):
 
         # get active libraries
         self.active_libs = []
-        for lib in lib_dict.values():
+        for lib in list(lib_dict.values()):
             if lib.prevalence >= min_lib_prevalence:
                 self.active_libs.append(lib.name)
 
@@ -623,7 +666,7 @@ class Sample(object):
         lib_dict = {}
 
         try:
-            for i in xrange(len(lib_info[name]['libraryArray'])):
+            for i in range(len(lib_info[name]['libraryArray'])):
                 lib = lib_info[name]['libraryArray'][i]
                 lib_name = lib['library_name']
 
@@ -637,7 +680,8 @@ class Sample(object):
                 for rg in lib['readgroups']:
                     rg_to_lib[rg] = lib_dict[lib_name]
         except KeyError:
-            sys.stderr.write('Error: sample %s not found in JSON library file.\n' % name)
+            sys.stderr.write(
+                'Error: sample %s not found in JSON library file.\n' % name)
             exit(1)
 
         return cls(name,
@@ -662,9 +706,9 @@ class Sample(object):
 
         for r in bam.header['RG']:
             try:
-                lib_name=r['LB']
-            except KeyError, e:
-                lib_name=''
+                lib_name = r['LB']
+            except KeyError as e:
+                lib_name = ''
 
             # add the new library
             if lib_name not in lib_dict:
@@ -683,7 +727,8 @@ class Sample(object):
 
     # get the maximum fetch flank for reading the BAM file
     def get_fetch_flank(self, z):
-        return max([lib.mean + (lib.sd * z) for lib in self.lib_dict.values()])
+        return max([lib.mean + (lib.sd * z)
+                    for lib in list(self.lib_dict.values())])
 
     # return the library object for a specified read group
     def get_lib(self, readgroup):
@@ -692,8 +737,10 @@ class Sample(object):
     # return the expected spanning coverage at any given base
     def set_exp_spanning_depth(self, min_aligned):
         genome_size = float(sum(self.bam.lengths))
-        weighted_mean_span = sum([(lib.mean - 2 * lib.read_length + 2 * min_aligned) * lib.prevalence for lib in self.lib_dict.values()])
-        exp_spanning_depth = (weighted_mean_span * self.bam_mapped) / genome_size
+        weighted_mean_span = sum(
+            [(lib.mean - 2 * lib.read_length + 2 * min_aligned) * lib.prevalence for lib in list(self.lib_dict.values())])
+        exp_spanning_depth = (
+            weighted_mean_span * self.bam_mapped) / genome_size
 
         self.exp_spanning_depth = exp_spanning_depth
 
@@ -702,8 +749,10 @@ class Sample(object):
     # return the expected sequence coverage at any given base
     def set_exp_seq_depth(self, min_aligned):
         genome_size = float(sum(self.bam.lengths))
-        weighted_mean_read_length = sum([(lib.read_length - 2 * min_aligned) * lib.prevalence for lib in self.lib_dict.values()])
-        exp_seq_depth = (weighted_mean_read_length * self.bam_mapped) / genome_size
+        weighted_mean_read_length = sum(
+            [(lib.read_length - 2 * min_aligned) * lib.prevalence for lib in list(self.lib_dict.values())])
+        exp_seq_depth = (
+            weighted_mean_read_length * self.bam_mapped) / genome_size
 
         self.exp_seq_depth = exp_seq_depth
 
@@ -712,12 +761,14 @@ class Sample(object):
     def close(self):
         self.bam.close()
 
+
 # ==================================================
 # Class for SAM fragment, containing all alignments
 # from a single molecule
 # ==================================================
 
 class SamFragment(object):
+
     def __init__(self, read, lib):
         self.lib = lib
         self.primary_reads = []
@@ -806,7 +857,6 @@ class SamFragment(object):
 
         return True
 
-
     # returns boolean of whether the primary pair of a
     # fragment straddles a genomic point
     def is_pair_straddle(self,
@@ -866,11 +916,13 @@ class SamFragment(object):
             var_length = self.lib.mean + self.lib.sd * z
 
         try:
-            p = float(self.lib.dens[ospan_length]) * conc_prior / (conc_prior * self.lib.dens[ospan_length] + disc_prior * (self.lib.dens[ospan_length - var_length]))
+            p = float(self.lib.dens[ospan_length]) * conc_prior / (
+                conc_prior * self.lib.dens[ospan_length] + disc_prior * (self.lib.dens[ospan_length - var_length]))
         except ZeroDivisionError:
             p = None
 
-        return p > 0.5
+        return None if p is None else p > 0.5
+
 
 # ==================================================
 # Class for a split-read, containing all alignments
@@ -880,6 +932,7 @@ class SamFragment(object):
 # each SplitRead object has a left and a right SplitPiece
 # (reads with more than 2 split alignments are discarded)
 class SplitRead(object):
+
     def __init__(self, read, lib):
         self.query_name = read.query_name
         self.read = read
@@ -891,6 +944,7 @@ class SplitRead(object):
 
     # the piece of each split alignemnt
     class SplitPiece(object):
+
         def __init__(self,
                      chrom,
                      reference_start,
@@ -907,7 +961,8 @@ class SplitRead(object):
             self.right_query = None
 
             # get query positions
-            self.query_pos = self.get_query_pos_from_cigar(self.cigar, self.is_reverse)
+            self.query_pos = self.get_query_pos_from_cigar(
+                self.cigar, self.is_reverse)
 
         # get the positions of the query that are aligned
         @staticmethod
@@ -921,20 +976,20 @@ class SplitRead(object):
                 cigar = cigar[::-1]
 
             # iterate through cigartuple
-            for i in xrange(len(cigar)):
+            for i in range(len(cigar)):
                 k, n = cigar[i]
-                if k in (4,5): # H, S
+                if k in (4, 5):  # H, S
                     if i == 0:
                         query_start += n
                         query_end += n
                         query_length += n
                     else:
                         query_length += n
-                elif k in (0,1,7,8): # M, I, =, X
+                elif k in (0, 1, 7, 8):  # M, I, =, X
                     query_end += n
-                    query_length +=n
+                    query_length += n
 
-            d = QueryPos(query_start, query_end, query_length);
+            d = QueryPos(query_start, query_end, query_length)
             return d
 
         def set_reference_end(self, reference_end):
@@ -948,15 +1003,18 @@ class SplitRead(object):
 
     # check if passes QC, and populate with necessary info
     def is_valid(self,
-                 min_non_overlap = 20,
-                 min_indel = 50,
-                 max_unmapped_bases = 50):
+                 min_non_overlap=20,
+                 min_indel=50,
+                 max_unmapped_bases=50):
         # check for SA tag
         if not self.read.has_tag('SA'):
-            # Include soft-clipped reads that didn't generate split-read alignments
+            # Include soft-clipped reads that didn't generate split-read
+            # alignments
             if self.is_clip_op(self.read.cigar[0][0]) or self.is_clip_op(self.read.cigar[-1][0]):
-                clip_length = max(self.read.cigar[0][1] * self.is_clip_op(self.read.cigar[0][0]), self.read.cigar[-1][1] * self.is_clip_op(self.read.cigar[-1][0]))
-                # Only count if the longest clipping event is greater than the cutoff and we have mapped a reasonable number of bases
+                clip_length = max(self.read.cigar[0][1] * self.is_clip_op(
+                    self.read.cigar[0][0]), self.read.cigar[-1][1] * self.is_clip_op(self.read.cigar[-1][0]))
+                # Only count if the longest clipping event is greater than the
+                # cutoff and we have mapped a reasonable number of bases
                 if clip_length > 0 and (self.read.query_length - self.read.query_alignment_length) <= max_unmapped_bases:
                     a = self.SplitPiece(self.read.reference_name,
                                         self.read.reference_start,
@@ -985,7 +1043,8 @@ class SplitRead(object):
         else:
             self.sa = sa_list[0].split(',')
             mate_chrom = self.sa[0]
-            mate_pos = int(self.sa[1]) - 1 # SA tag is one-based, while SAM is zero-based
+            mate_pos = int(
+                self.sa[1]) - 1  # SA tag is one-based, while SAM is zero-based
             mate_is_reverse = self.sa[2] == '-'
             mate_cigar = self.cigarstring_to_tuple(self.sa[3])
             mate_mapq = int(self.sa[4])
@@ -1003,7 +1062,8 @@ class SplitRead(object):
                             mate_is_reverse,
                             mate_cigar,
                             mate_mapq)
-        b.set_reference_end(self.get_reference_end_from_cigar(b.reference_start, b.cigar))
+        b.set_reference_end(
+            self.get_reference_end_from_cigar(b.reference_start, b.cigar))
 
         # set query_left and query_right splitter by alignment position on the reference
         # this is used for non-overlap and off-diagonal filtering
@@ -1025,7 +1085,7 @@ class SplitRead(object):
         # check off-diagonal distance and desert
         # only relevant when split pieces are on the same chromosome and strand
         if (self.query_left.chrom == self.query_right.chrom
-            and self.query_left.is_reverse == self.query_right.is_reverse):
+                and self.query_left.is_reverse == self.query_right.is_reverse):
             # use end diagonal on left and start diagonal on right since
             # the start and end diags might be different if there is an
             # indel in the alignments
@@ -1041,7 +1101,8 @@ class SplitRead(object):
                 return False
 
             # check for desert gap of indels
-            desert = self.query_right.query_pos.query_start - self.query_left.query_pos.query_end - 1
+            desert = self.query_right.query_pos.query_start - \
+                self.query_left.query_pos.query_end - 1
             if desert > 0 and desert - max(0, ins_size) > max_unmapped_bases:
                 return False
 
@@ -1054,7 +1115,8 @@ class SplitRead(object):
     def get_start_diagonal(split_piece):
         sclip = split_piece.query_pos.query_start
         if split_piece.is_reverse:
-            sclip = split_piece.query_pos.query_length - split_piece.query_pos.query_end
+            sclip = split_piece.query_pos.query_length - \
+                split_piece.query_pos.query_end
         return split_piece.reference_start - sclip
 
     # reference position where the alignment would have ended
@@ -1063,17 +1125,21 @@ class SplitRead(object):
     def get_end_diagonal(split_piece):
         query_aligned = split_piece.query_pos.query_end
         if split_piece.is_reverse:
-            query_aligned = split_piece.query_pos.query_length - split_piece.query_pos.query_start
+            query_aligned = split_piece.query_pos.query_length - \
+                split_piece.query_pos.query_start
         return split_piece.reference_end - query_aligned
 
-
-    # adapted from Matt Shirley (http://coderscrowd.com/app/public/codes/view/171)
+    # adapted from Matt Shirley
+    # (http://coderscrowd.com/app/public/codes/view/171)
     @staticmethod
     def cigarstring_to_tuple(cigarstring):
-        cigar_dict = {'M':0, 'I':1,'D':2,'N':3, 'S':4, 'H':5, 'P':6, '=':7, 'X':8}
+        cigar_dict = {'M': 0, 'I': 1, 'D': 2, 'N': 3, 'S': 4,
+                      'H': 5, 'P': 6, '=': 7, 'X': 8}
         pattern = re.compile('([MIDNSHPX=])')
-        values = pattern.split(cigarstring)[:-1] ## turn cigar into tuple of values
-        paired = (values[n:n+2] for n in xrange(0, len(values), 2)) ## pair values by twos
+        values = pattern.split(cigarstring)[
+            :-1]  # turn cigar into tuple of values
+        paired = (values[n:n + 2]
+                  for n in range(0, len(values), 2))  # pair values by twos
         return [(cigar_dict[pair[1]], int(pair[0])) for pair in paired]
 
     @staticmethod
@@ -1083,11 +1149,11 @@ class SplitRead(object):
         This matches the behavior of pysam's reference_end method
         '''
         reference_end = reference_start
-        
+
         # iterate through cigartuple
-        for i in xrange(len(cigar)):
+        for i in range(len(cigar)):
             k, n = cigar[i]
-            if k in (0,2,3,7,8): # M, D, N, =, X
+            if k in (0, 2, 3, 7, 8):  # M, D, N, =, X
                 reference_end += n
         return reference_end
 
@@ -1099,8 +1165,10 @@ class SplitRead(object):
                                          self.query_right.query_pos.query_end)
 
         # get minimum non-overlap
-        left_non_overlap = 1 + self.query_left.query_pos.query_end - self.query_left.query_pos.query_start - overlap
-        right_non_overlap = 1 + self.query_right.query_pos.query_end - self.query_right.query_pos.query_start - overlap
+        left_non_overlap = 1 + self.query_left.query_pos.query_end - \
+            self.query_left.query_pos.query_start - overlap
+        right_non_overlap = 1 + self.query_right.query_pos.query_end - \
+            self.query_right.query_pos.query_start - overlap
         non_overlap = min(left_non_overlap, right_non_overlap)
 
         return non_overlap
@@ -1132,7 +1200,7 @@ class SplitRead(object):
 
         # arrange the SV breakends from left to right
         if (chromA != chromB
-            or (chromA == chromB and posA > posB)):
+                or (chromA == chromB and posA > posB)):
             chrom_left = chromB
             pos_left = posB
             ci_left = ciB
@@ -1151,56 +1219,55 @@ class SplitRead(object):
             ci_right = ciB
             is_reverse_right = o2_is_reverse
 
-
         # check split chromosomes against variant
         left_split = False
         right_split = False
 
         if (not self.is_soft_clip) or svtype == 'DEL' or svtype == 'INS':
             left_split = self.check_split_support(self.query_left,
-                    chrom_left,
-                    pos_left,
-                    is_reverse_left,
-                    split_slop)
+                                                  chrom_left,
+                                                  pos_left,
+                                                  is_reverse_left,
+                                                  split_slop)
             right_split = self.check_split_support(self.query_right,
-                    chrom_right,
-                    pos_right,
-                    is_reverse_right,
-                    split_slop)
+                                                   chrom_right,
+                                                   pos_right,
+                                                   is_reverse_right,
+                                                   split_slop)
         elif svtype == 'DUP':
             left_split = self.check_split_support(self.query_left,
-                    chrom_right,
-                    pos_right,
-                    is_reverse_right,
-                    split_slop)
+                                                  chrom_right,
+                                                  pos_right,
+                                                  is_reverse_right,
+                                                  split_slop)
             right_split = self.check_split_support(self.query_right,
-                    chrom_left,
-                    pos_left,
-                    is_reverse_left,
-                    split_slop)
+                                                   chrom_left,
+                                                   pos_left,
+                                                   is_reverse_left,
+                                                   split_slop)
         elif svtype == 'INV':
                 # check all possible sides
             left_split_left = self.check_split_support(self.query_left,
-                    chrom_left,
-                    pos_left,
-                    is_reverse_left,
-                    split_slop)
+                                                       chrom_left,
+                                                       pos_left,
+                                                       is_reverse_left,
+                                                       split_slop)
             left_split_right = self.check_split_support(self.query_left,
-                    chrom_right,
-                    pos_right,
-                    is_reverse_right,
-                    split_slop)
+                                                        chrom_right,
+                                                        pos_right,
+                                                        is_reverse_right,
+                                                        split_slop)
             left_split = left_split_left or left_split_right
             right_split_left = self.check_split_support(self.query_right,
-                    chrom_left,
-                    pos_left,
-                    is_reverse_left,
-                    split_slop)
+                                                        chrom_left,
+                                                        pos_left,
+                                                        is_reverse_left,
+                                                        split_slop)
             right_split_right = self.check_split_support(self.query_right,
-                    chrom_right,
-                    pos_right,
-                    is_reverse_right,
-                    split_slop)
+                                                         chrom_right,
+                                                         pos_right,
+                                                         is_reverse_right,
+                                                         split_slop)
             right_split = right_split_left or right_split_right
 
         return (left_split, right_split)
@@ -1246,11 +1313,12 @@ class SplitRead(object):
 
 # structure to hold query position information
 class QueryPos (object):
+
     """
     struct to store the start and end positions of query CIGAR operations
     """
+
     def __init__(self, query_start, query_end, query_length):
         self.query_start = int(query_start)
         self.query_end = int(query_end)
-        self.query_length  = int(query_length)
-
+        self.query_length = int(query_length)

--- a/svtyper/singlesample.py
+++ b/svtyper/singlesample.py
@@ -449,6 +449,9 @@ def tally_variant_read_fragments(split_slop, min_aligned, breakpoint, sam_fragme
     if alt_span < 0.5 and (alt_seq + alt_clip) >= 1:
         alt_span = 0
         ref_span = 0
+    if alt_span + alt_seq == 0 and alt_clip > 0:
+        # discount any SV that's only supported by clips.
+        alt_clip = 0
 
     counts = {'ref_seq': ref_seq, 'alt_seq': alt_seq,
               'ref_span': ref_span, 'alt_span': alt_span,

--- a/svtyper/statistics.py
+++ b/svtyper/statistics.py
@@ -6,13 +6,15 @@ from collections import Counter
 # ==================================================
 
 # efficient combinatorial function to handle extremely large numbers
+
+
 def log_choose(n, k):
     r = 0.0
     # swap for efficiency if k is more than half of n
     if k * 2 > n:
         k = n - k
 
-    for  d in xrange(1,k+1):
+    for d in range(1, k + 1):
         r += math.log(n, 10)
         r -= math.log(d, 10)
         n -= 1
@@ -20,31 +22,41 @@ def log_choose(n, k):
     return r
 
 # return the genotype and log10 p-value
+
+
 def bayes_gt(ref, alt, is_dup):
-    # probability of seeing an alt read with true genotype of of hom_ref, het, hom_alt respectively
-    if is_dup: # specialized logic to handle non-destructive events such as duplications
-        p_alt = [1e-2, 0.2, 1/3.0]
+    # probability of seeing an alt read with true genotype of of hom_ref, het,
+    # hom_alt respectively
+    if is_dup:  # specialized logic to handle non-destructive events such as duplications
+        p_alt = [1e-2, 0.2, 1 / 3.0]
     else:
         p_alt = [1e-3, 0.5, 0.9]
 
     total = ref + alt
     log_combo = log_choose(total, alt)
 
-    lp_homref = log_combo + alt * math.log(p_alt[0], 10) + ref * math.log(1 - p_alt[0], 10)
-    lp_het = log_combo + alt * math.log(p_alt[1], 10) + ref * math.log(1 - p_alt[1], 10)
-    lp_homalt = log_combo + alt * math.log(p_alt[2], 10) + ref * math.log(1 - p_alt[2], 10)
+    lp_homref = log_combo + alt * \
+        math.log(p_alt[0], 10) + ref * math.log(1 - p_alt[0], 10)
+    lp_het = log_combo + alt * \
+        math.log(p_alt[1], 10) + ref * math.log(1 - p_alt[1], 10)
+    lp_homalt = log_combo + alt * \
+        math.log(p_alt[2], 10) + ref * math.log(1 - p_alt[2], 10)
 
     return (lp_homref, lp_het, lp_homalt)
 
 # get the number of entries in the set
+
+
 def countRecords(myCounter):
     numRecords = sum(myCounter.values())
     return numRecords
 
 # median is approx 50th percentile, except when it is between
 # two values in which case it's the mean of them.
+
+
 def median(myCounter):
-    #length is the number of bases we're looking at
+    # length is the number of bases we're looking at
     numEntries = countRecords(myCounter)
 
     # the ordinal value of the middle element
@@ -75,6 +87,8 @@ def median(myCounter):
         return v
 
 # calculate upper median absolute deviation
+
+
 def upper_mad(myCounter, myMedian):
     residCounter = Counter()
     for x in myCounter:
@@ -83,6 +97,8 @@ def upper_mad(myCounter, myMedian):
     return median(residCounter)
 
 # sum of the entries
+
+
 def sumRecords(myCounter):
     mySum = 0.0
     for c in myCounter:
@@ -93,6 +109,8 @@ def sumRecords(myCounter):
 # length of the feature (chromosome or genome)
 # for x percentile, x% of the elements in the set are
 # <= the output value
+
+
 def mean(myCounter):
     # the number of total entries in the set is the
     # sum of the occurrences for each value
@@ -103,6 +121,7 @@ def mean(myCounter):
 
     u = sumRecords(myCounter) / numRecords
     return u
+
 
 def stdev(myCounter):
     # the number of total entries in the set is the
@@ -119,4 +138,3 @@ def stdev(myCounter):
     myVariance = float(sumVar) / numRecords
     stdev = myVariance**(0.5)
     return stdev
-

--- a/svtyper/utils.py
+++ b/svtyper/utils.py
@@ -1,6 +1,14 @@
-from __future__ import print_function
 
-import sys, time, datetime, os, contextlib, tempfile, shutil, json, re
+
+import sys
+import time
+import datetime
+import os
+import contextlib
+import tempfile
+import shutil
+import json
+import re
 from functools import wraps
 
 from svtyper.parsers import SamFragment, Vcf
@@ -10,6 +18,8 @@ from svtyper.parsers import SamFragment, Vcf
 # ==================================================
 
 # write read to BAM file, checking whether read is already written
+
+
 def write_alignment(read, bam, written_reads, is_alt=None):
     read.query_sequence = None
     read_hash = (read.query_name, read.flag)
@@ -22,17 +32,19 @@ def write_alignment(read, bam, written_reads, is_alt=None):
         return written_reads
 
 # dump the sample and library info to a file
+
+
 def write_sample_json(sample_list, lib_info_file):
     lib_info = {}
     for sample in sample_list:
         s = {}
         s['sample_name'] = sample.name
-        s['bam'] = sample.bam.filename
+        s['bam'] = os.fsdecode(sample.bam.filename)
         s['libraryArray'] = []
         s['mapped'] = sample.bam.mapped
         s['unmapped'] = sample.bam.unmapped
 
-        for lib in sample.lib_dict.values():
+        for lib in list(sample.lib_dict.values()):
             l = {}
             l['library_name'] = lib.name
             l['readgroups'] = lib.readgroups
@@ -53,15 +65,20 @@ def write_sample_json(sample_list, lib_info_file):
 # ==================================================
 # Sorting Functions
 # ==================================================
+
+
 def sort_regions(region):
-    str_region = [ str(i) for i in region ]
+    str_region = [str(i) for i in region]
     key = '--'.join([str_region[i] for i in (0, 1, 3, 4)])
     return [int(s) if s.isdigit() else s for s in re.split(r'(\d+)', key)]
 
+
 def sort_reads(read):
-    attrs = ('reference_name', 'reference_start', 'reference_end', 'query_name')
+    attrs = ('reference_name', 'reference_start',
+             'reference_end', 'query_name')
     key = '--'.join([str(getattr(read, i)) for i in attrs])
     return [int(s) if s.isdigit() else s for s in re.split(r'(\d+)', key)]
+
 
 def sort_chroms(chrom):
     return [int(s) if s.isdigit() else s for s in re.split(r'(\d+)', chrom)]
@@ -71,12 +88,15 @@ def sort_chroms(chrom):
 # ==================================================
 
 # get the non-phred-scaled mapq of a read
+
+
 def prob_mapq(read):
     return 1 - 10 ** (-read.mapping_quality / 10.0)
 
 # ==================================================
 # logging
 # ==================================================
+
 
 def logit(msg):
     ts = time.strftime("[ %Y-%m-%d %T ]", datetime.datetime.now().timetuple())
@@ -88,9 +108,11 @@ def logit(msg):
 # temporary directory handling
 # ==================================================
 
+
 def is_lsf_job():
     rv = 'LSB_JOBID' in os.environ
     return rv
+
 
 @contextlib.contextmanager
 def cd(newdir, cleanup=lambda: True):
@@ -101,6 +123,7 @@ def cd(newdir, cleanup=lambda: True):
     finally:
         os.chdir(prevdir)
         cleanup()
+
 
 @contextlib.contextmanager
 def tempdir():
@@ -127,6 +150,7 @@ def vcf_variants(vcf_file):
             if not line.startswith('#'):
                 yield line
 
+
 def vcf_headers(vcf_file):
     with open(vcf_file, 'r') as f:
         for line in f:
@@ -134,6 +158,7 @@ def vcf_headers(vcf_file):
                 yield line
             else:
                 break
+
 
 def vcf_samples(vcf_file):
     samples = []
@@ -147,5 +172,7 @@ def vcf_samples(vcf_file):
 # ==================================================
 # system helpers
 # ==================================================
+
+
 def die(msg):
     sys.exit(msg)

--- a/svtyper/version.py
+++ b/svtyper/version.py
@@ -1,2 +1,2 @@
 __author__ = "Colby Chiang (colbychiang@wustl.edu)"
-__version__ = "v0.5.2"
+__version__ = "v0.6.0"

--- a/svtyper/version.py
+++ b/svtyper/version.py
@@ -1,2 +1,2 @@
 __author__ = "Colby Chiang (colbychiang@wustl.edu)"
-__version__ = "v0.6.0"
+__version__ = "v0.5.2"

--- a/tests/test_singlesample.py
+++ b/tests/test_singlesample.py
@@ -1,6 +1,8 @@
 
 from .context import singlesample as s
-import unittest, os, subprocess
+import unittest
+import os
+import subprocess
 
 HERE = os.path.dirname(__file__)
 in_vcf = os.path.join(HERE, "data/example.vcf")
@@ -9,7 +11,9 @@ lib_info_json = os.path.join(HERE, "data/NA12878.bam.json")
 out_vcf = os.path.join(HERE, "data/out.vcf")
 expected_out_vcf = os.path.join(HERE, "data/example.gt.vcf")
 
+
 class TestIntegration(unittest.TestCase):
+
     def setUp(self):
         pass
 
@@ -34,13 +38,16 @@ class TestIntegration(unittest.TestCase):
                            cores=None,
                            batch_size=1000)
 
-        fail_msg = "did not find output vcf '{}' after running sv_genotype".format(out_vcf)
+        fail_msg = "did not find output vcf '{}' after running sv_genotype".format(
+            out_vcf)
         self.assertTrue(os.path.exists(out_vcf), fail_msg)
 
         fail_msg = ("output vcf '{}' "
                     "did not match expected "
                     "output vcf '{}'").format(out_vcf, expected_out_vcf)
-        self.assertTrue(self.diff(), fail_msg)
+        if not self.diff():
+            exit(1)
+        #self.assertTrue(self.diff(), fail_msg)
 
     def test_parallel_integration(self):
         with open(in_vcf, "r") as inf, open(out_vcf, "w") as outf:
@@ -59,7 +66,8 @@ class TestIntegration(unittest.TestCase):
                            cores=1,
                            batch_size=1000)
 
-        fail_msg = "did not find output vcf '{}' after running sv_genotype".format(out_vcf)
+        fail_msg = "did not find output vcf '{}' after running sv_genotype".format(
+            out_vcf)
         self.assertTrue(os.path.exists(out_vcf), fail_msg)
 
         fail_msg = ("output vcf '{}' "

--- a/tests/test_svtyper.py
+++ b/tests/test_svtyper.py
@@ -1,7 +1,9 @@
 
 from .context import parsers as p
 from .context import classic
-import unittest, os, subprocess
+import unittest
+import os
+import subprocess
 
 HERE = os.path.dirname(__file__)
 in_vcf = os.path.join(HERE, "data/example.vcf")
@@ -10,26 +12,30 @@ lib_info_json = os.path.join(HERE, "data/NA12878.bam.json")
 out_vcf = os.path.join(HERE, "data/out.vcf")
 expected_out_vcf = os.path.join(HERE, "data/example.gt.vcf")
 
+
 class TestCigarParsing(unittest.TestCase):
+
     def test_cigarstring_to_tuple(self):
         string1 = '5H3S2D1N5M3I2P2X1='
         self.assertEqual(p.SplitRead.cigarstring_to_tuple(string1),
-                [(5, 5), (4, 3), (2, 2), (3, 1),
-                    (0, 5), (1, 3), (6, 2), (8, 2),
-                    (7, 1)])
+                         [(5, 5), (4, 3), (2, 2), (3, 1),
+                          (0, 5), (1, 3), (6, 2), (8, 2),
+                          (7, 1)])
 
     def test_get_query_pos_from_cigar(self):
         # forward
         cigar_string = '2S3M1D2M2I3M3S'
         cigar = p.SplitRead.cigarstring_to_tuple(cigar_string)
-        query_pos = p.SplitRead.SplitPiece.get_query_pos_from_cigar(cigar, True)
+        query_pos = p.SplitRead.SplitPiece.get_query_pos_from_cigar(
+            cigar, True)
         self.assertEqual(query_pos.query_start, 3)
         self.assertEqual(query_pos.query_end, 13)
         self.assertEqual(query_pos.query_length, 15)
 
         # get_query_pos_from_cigar currently modifies the cigar list in place.
         # that's why the code below doesn't work as intended.
-        query_pos = p.SplitRead.SplitPiece.get_query_pos_from_cigar(cigar, False)
+        query_pos = p.SplitRead.SplitPiece.get_query_pos_from_cigar(
+            cigar, False)
         self.assertEqual(query_pos.query_start, 2)
         self.assertEqual(query_pos.query_end, 12)
         self.assertEqual(query_pos.query_length, 15)
@@ -37,25 +43,34 @@ class TestCigarParsing(unittest.TestCase):
     def test_get_reference_end_from_cigar(self):
         cigar_string = '2S5M3D2M3S'
         cigar = p.SplitRead.cigarstring_to_tuple(cigar_string)
-        self.assertEqual(p.SplitRead.get_reference_end_from_cigar(1, cigar), 11)
+        self.assertEqual(
+            p.SplitRead.get_reference_end_from_cigar(1, cigar), 11)
 
     def test_get_start_diagonal(self):
         cigar_string = '2S5M3D1I1M3S'
-        split_piece = p.SplitRead.SplitPiece(1, 25, True, p.SplitRead.cigarstring_to_tuple(cigar_string), 60)
+        split_piece = p.SplitRead.SplitPiece(
+            1, 25, True, p.SplitRead.cigarstring_to_tuple(cigar_string), 60)
         self.assertEqual(p.SplitRead.get_start_diagonal(split_piece), 23)
-        split_piece2 = p.SplitRead.SplitPiece(1, 25, False, p.SplitRead.cigarstring_to_tuple(cigar_string), 60)
+        split_piece2 = p.SplitRead.SplitPiece(
+            1, 25, False, p.SplitRead.cigarstring_to_tuple(cigar_string), 60)
         self.assertEqual(p.SplitRead.get_start_diagonal(split_piece2), 23)
 
     def test_get_end_diagonal(self):
         cigar_string = '2S5M3D2I1M3S'
-        split_piece = p.SplitRead.SplitPiece(1, 25, True, p.SplitRead.cigarstring_to_tuple(cigar_string), 60)
+        split_piece = p.SplitRead.SplitPiece(
+            1, 25, True, p.SplitRead.cigarstring_to_tuple(cigar_string), 60)
         split_piece.set_reference_end(34)
-        self.assertEqual(p.SplitRead.get_end_diagonal(split_piece), 34 - (2 + 8))
-        split_piece2 = p.SplitRead.SplitPiece(1, 25, False, p.SplitRead.cigarstring_to_tuple(cigar_string), 60)
+        self.assertEqual(
+            p.SplitRead.get_end_diagonal(split_piece), 34 - (2 + 8))
+        split_piece2 = p.SplitRead.SplitPiece(
+            1, 25, False, p.SplitRead.cigarstring_to_tuple(cigar_string), 60)
         split_piece2.set_reference_end(34)
-        self.assertEqual(p.SplitRead.get_end_diagonal(split_piece2), 34 - (2 + 8))
+        self.assertEqual(
+            p.SplitRead.get_end_diagonal(split_piece2), 34 - (2 + 8))
+
 
 class TestIntegration(unittest.TestCase):
+
     def setUp(self):
         pass
 
@@ -66,20 +81,21 @@ class TestIntegration(unittest.TestCase):
     def test_integration(self):
         with open(in_vcf, "r") as inf, open(out_vcf, "w") as outf:
             classic.sv_genotype(bam_string=in_bam,
-                             vcf_in=inf,
-                             vcf_out=outf,
-                             min_aligned=20,
-                             split_weight=1,
-                             disc_weight=1,
-                             num_samp=1000000,
-                             lib_info_path=lib_info_json,
-                             debug=False,
-                             alignment_outpath=None,
-                             ref_fasta=None,
-                             sum_quals=False,
-                             max_reads=None)
+                                vcf_in=inf,
+                                vcf_out=outf,
+                                min_aligned=20,
+                                split_weight=1,
+                                disc_weight=1,
+                                num_samp=1000000,
+                                lib_info_path=lib_info_json,
+                                debug=False,
+                                alignment_outpath=None,
+                                ref_fasta=None,
+                                sum_quals=False,
+                                max_reads=None)
 
-        fail_msg = "did not file output vcf '{}' after running sv_genotype".format(out_vcf)
+        fail_msg = "did not file output vcf '{}' after running sv_genotype".format(
+            out_vcf)
         self.assertTrue(os.path.exists(out_vcf), fail_msg)
 
         fail_msg = ("output vcf '{}' "


### PR DESCRIPTION
We port svtyper to python3.

We add svtyper-pms script which will parallelize by individuals (instead of parallelize by batch for an unique individual, like svtyper-sso). This script will launch in parallel the genotyping of 1 individual. Then, it uses bcftools to merge all VCF.

Due to python3 conversion, some tests failed. It looks like the difference is due to impact of taking the interger part for sum of floats of different precisions. Details in join file:

[python3_python2_diff.txt](https://github.com/hall-lab/svtyper/files/1937832/python3_python2_diff.txt)
