### PR TITLE
improve svtyper speed by ~30%

### DIFF
--- a/svtyper/classic.py
+++ b/svtyper/classic.py
@@ -123,7 +123,8 @@ def sv_genotype(bam_string,
         if b.endswith('.bam'):
             bam_list.append(pysam.AlignmentFile(b, mode='rb'))
         elif b.endswith('.cram'):
-            bam_list.append(pysam.AlignmentFile(b, mode='rc', reference_filename=ref_fasta))
+            bam_list.append(pysam.AlignmentFile(b,
+                mode='rc',reference_filename=ref_fasta,format_options=["required_fields=7167"]))
         else:
             sys.stderr.write('Error: %s is not a valid alignment file (*.bam or *.cram)\n' % b)
             exit(1)

--- a/svtyper/parsers.py
+++ b/svtyper/parsers.py
@@ -717,6 +717,9 @@ class Sample(object):
 # from a single molecule
 # ==================================================
 
+def rhash(r):
+    return hash((r.query_name, r.flag))
+
 class SamFragment(object):
     def __init__(self, read, lib):
         self.lib = lib
@@ -738,7 +741,7 @@ class SamFragment(object):
 
     def add_read(self, read):
         # ensure we don't add the same read twice
-        read_hash = read.__hash__()
+        read_hash = rhash(read)
         if read_hash in self.read_set:
             return
         else:


### PR DESCRIPTION
avoids use of CRAM sequence and base-quals which otherwise do
not need to be decoded.

This changes the run-time of one test-case from

20.8 seconds to 14.9