### PR TITLE
Fixed #103 (KeyError: 'CIPOS') 

### DIFF
--- a/svtyper/parsers.py
+++ b/svtyper/parsers.py
@@ -15,7 +15,10 @@ def confidence_interval(var, tag, alt_tag, max_ci_dist):
         return [0, 0]
         
     if ci[1] - ci[0] > max_ci_dist:
-        return map(int, var.info[alt_tag].split(','))
+        try:
+            ci = map(int, var.info[alt_tag].split(','))
+        except KeyError as e:
+            return [0, 0]
     return ci
 
 

--- a/svtyper/parsers.py
+++ b/svtyper/parsers.py
@@ -12,10 +12,7 @@ def confidence_interval(var, tag, alt_tag, max_ci_dist):
     try:
         ci = map(int, var.info[tag].split(','))
     except KeyError as e:
-        if str(e) == 'CIPOS':
-            return [0, 0]
-        else:
-            raise
+        return [0, 0]
         
     if ci[1] - ci[0] > max_ci_dist:
         return map(int, var.info[alt_tag].split(','))

--- a/svtyper/parsers.py
+++ b/svtyper/parsers.py
@@ -9,7 +9,14 @@ from svtyper.statistics import mean, stdev, median, upper_mad
 # VCF parsing tools
 # ==================================================
 def confidence_interval(var, tag, alt_tag, max_ci_dist):
-    ci = map(int, var.info[tag].split(','))
+    try:
+        ci = map(int, var.info[tag].split(','))
+    except KeyError as e:
+        if str(e) == 'CIPOS':
+            return [0, 0]
+        else:
+            raise
+        
     if ci[1] - ci[0] > max_ci_dist:
         return map(int, var.info[alt_tag].split(','))
     return ci


### PR DESCRIPTION
- This pull requests fixes issue #103 where svtyper fails with a KeyError due to the input VCF missing "CIPOS" information.

-  Fix consists of adding a try block around the offending code and setting `ci = [0, 0]`
